### PR TITLE
feat: add study page with spaced repetition for reading practice

### DIFF
--- a/public/exercises_1.yaml
+++ b/public/exercises_1.yaml
@@ -1,0 +1,42031 @@
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 是
+    pinyin: shì
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 。
+    pinyin: ''
+  english: I am a student.
+
+- segments:
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 去
+    pinyin: qù
+  - chinese: 图书馆
+    pinyin: tú shū guǎn
+  - chinese: 。
+    pinyin: ''
+  english: I will go to the library tomorrow.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 。
+    pinyin: ''
+  english: I really like this piece of clothing.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 忘记
+    pinyin: wàng jì
+  - chinese: 带
+    pinyin: dài
+  - chinese: 钥匙
+    pinyin: yào shi
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I forgot to bring my keys.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 中餐
+    pinyin: zhōng cān
+  - chinese: 。
+    pinyin: ''
+  english: I want to eat Chinese food.
+
+- segments:
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 早上
+    pinyin: zǎo shang
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 会
+    pinyin: huì
+  - chinese: 跑步
+    pinyin: pǎo bù
+  - chinese: 。
+    pinyin: ''
+  english: I go running every morning.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 要
+    pinyin: yào
+  - chinese: 花
+    pinyin: huā
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 汉语
+    pinyin: Hàn yǔ
+  - chinese: 。
+    pinyin: ''
+  english: He spends an hour studying Chinese every day.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 晚上
+    pinyin: wǎn shang
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 会
+    pinyin: huì
+  - chinese: 阅读
+    pinyin: yuè dú
+  - chinese: 一会儿
+    pinyin: yī huì r
+  - chinese: 。
+    pinyin: ''
+  english: She reads for a while every evening.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 饺子
+    pinyin: jiǎo zi
+  - chinese: 。
+    pinyin: ''
+  english: I like to eat dumplings.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 汉语
+    pinyin: Hàn yǔ
+  - chinese: 。
+    pinyin: ''
+  english: I can speak Chinese.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 名字
+    pinyin: míng zi
+  - chinese: 是
+    pinyin: shì
+  - chinese: 李
+    pinyin: lǐ
+  - chinese: 明
+    pinyin: míng
+  - chinese: 。
+    pinyin: ''
+  english: My name is Li Ming.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 家乡
+    pinyin: jiā xiāng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 北京
+    pinyin: Běi jīng
+  - chinese: 。
+    pinyin: ''
+  english: My hometown is in Beijing.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 忙
+    pinyin: máng
+  - chinese: 。
+    pinyin: ''
+  english: I am very busy today.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 。
+    pinyin: ''
+  english: I drink coffee every day.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 锻
+    pinyin: duàn
+  - chinese: 炼
+    pinyin: liàn
+  - chinese: 身
+    pinyin: shēn
+  - chinese: 体
+    pinyin: tǐ
+  - chinese: 。
+    pinyin: ''
+  english: He exercises every day.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 学
+    pinyin: xué
+  - chinese: 习
+    pinyin: xí
+  - chinese: 中文
+    pinyin: Zhōng wén
+  - chinese: 。
+    pinyin: ''
+  english: We study Chinese every day.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 孩子
+    pinyin: hái zi
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 开心
+    pinyin: kāi xīn
+  - chinese: 。
+    pinyin: ''
+  english: This child is happy every day.
+
+- segments:
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 的
+    pinyin: de
+  - chinese: 机会
+    pinyin: jī huì
+  - chinese: 。
+    pinyin: ''
+  english: Every day brings new opportunities.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 蓝
+    pinyin: lán
+  - chinese: 色
+    pinyin: sè
+  - chinese: 。
+    pinyin: ''
+  english: I like the color blue.
+
+- segments:
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 的
+    pinyin: de
+  - chinese: 墙壁
+    pinyin: qiáng bì
+  - chinese: 是
+    pinyin: shì
+  - chinese: 蓝
+    pinyin: lán
+  - chinese: 色
+    pinyin: sè
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: The walls of the room are blue.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 穿
+    pinyin: chuān
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 条
+    pinyin: tiáo
+  - chinese: 蓝
+    pinyin: lán
+  - chinese: 色
+    pinyin: sè
+  - chinese: 的
+    pinyin: de
+  - chinese: 裙子
+    pinyin: qún zi
+  - chinese: 。
+    pinyin: ''
+  english: She is wearing a blue dress.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 画廊
+    pinyin: huà láng
+  - chinese: 展示
+    pinyin: zhǎn shì
+  - chinese: 了
+    pinyin: le
+  - chinese: 许多
+    pinyin: xǔ duō
+  - chinese: 蓝
+    pinyin: lán
+  - chinese: 色
+    pinyin: sè
+  - chinese: 的
+    pinyin: de
+  - chinese: 画作
+    pinyin: huà zuò
+  - chinese: 。
+    pinyin: ''
+  english: This art gallery showcases many blue paintings.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 手机
+    pinyin: shǒu jī
+  - chinese: 壳
+    pinyin: ké
+  - chinese: 是
+    pinyin: shì
+  - chinese: 蓝
+    pinyin: lán
+  - chinese: 色
+    pinyin: sè
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: My phone case is blue.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 穿
+    pinyin: chuān
+  - chinese: 袜子
+    pinyin: wà zi
+  - chinese: 。
+    pinyin: ''
+  english: I wear socks.
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 双
+    pinyin: shuāng
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 袜子
+    pinyin: wà zi
+  - chinese: 。
+    pinyin: ''
+  english: Mom bought me a new pair of socks.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 双
+    pinyin: shuāng
+  - chinese: 袜子
+    pinyin: wà zi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 舒服
+    pinyin: shū fu
+  - chinese: 。
+    pinyin: ''
+  english: These socks are very comfortable.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 穿
+    pinyin: chuān
+  - chinese: 彩色
+    pinyin: cǎi sè
+  - chinese: 的
+    pinyin: de
+  - chinese: 袜子
+    pinyin: wà zi
+  - chinese: 。
+    pinyin: ''
+  english: I like to wear colorful socks.
+
+- segments:
+  - chinese: 穿
+    pinyin: chuān
+  - chinese: 袜子
+    pinyin: wà zi
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 保暖
+    pinyin: bǎo nuǎn
+  - chinese: 。
+    pinyin: ''
+  english: Wearing socks can keep you warm.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 摔
+    pinyin: shuāi
+  - chinese: 倒
+    pinyin: dǎo
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 疼
+    pinyin: téng
+  - chinese: 到
+    pinyin: dào
+  - chinese: 屁股
+    pinyin: pì gu
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: He fell down and hurt his butt.
+
+- segments:
+  - chinese: 孩子
+    pinyin: hái zi
+  - chinese: 生气
+    pinyin: shēng qì
+  - chinese: 时
+    pinyin: shí
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 拍打
+    pinyin: pāi da
+  - chinese: 屁股
+    pinyin: pì gu
+  - chinese: 。
+    pinyin: ''
+  english: Children tend to slap their bottoms when they are angry.
+
+- segments:
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 硬
+    pinyin: yìng
+  - chinese: 椅子
+    pinyin: yǐ zi
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 时
+    pinyin: shí
+  - chinese: 会
+    pinyin: huì
+  - chinese: 感到
+    pinyin: gǎn dào
+  - chinese: 屁股
+    pinyin: pì gu
+  - chinese: 酸痛
+    pinyin: suān tòng
+  - chinese: 。
+    pinyin: ''
+  english: Sitting on a hard chair sometimes makes your butt sore.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 久
+    pinyin: jiǔ
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 不
+    pinyin: bù
+  - chinese: 动
+    pinyin: dòng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 屁股
+    pinyin: pì gu
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 麻
+    pinyin: má
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: She sat for too long and her butt went numb.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 医生
+    pinyin: yī shēng
+  - chinese: 。
+    pinyin: ''
+  english: He is a doctor.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 。
+    pinyin: ''
+  english: She is my friend.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 星期一
+    pinyin: Xīng qī yī
+  - chinese: 。
+    pinyin: ''
+  english: Today is Monday.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: This is my book.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 钥匙
+    pinyin: yào shi
+  - chinese: 。
+    pinyin: ''
+  english: This is your key.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 鼻子
+    pinyin: bí zi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 大
+    pinyin: dà
+  - chinese: 。
+    pinyin: ''
+  english: His nose is big.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 鼻子
+    pinyin: bí zi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 。
+    pinyin: ''
+  english: Her nose is very pretty.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 鼻子
+    pinyin: bí zi
+  - chinese: 感冒
+    pinyin: gǎn mào
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: My nose is congested.
+
+- segments:
+  - chinese: 小
+    pinyin: xiǎo
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 的
+    pinyin: de
+  - chinese: 鼻子
+    pinyin: bí zi
+  - chinese: 是
+    pinyin: shì
+  - chinese: 黑色
+    pinyin: hēi sè
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: The kitten's nose is black.
+
+- segments:
+  - chinese: 别
+    pinyin: bié
+  - chinese: 摸
+    pinyin: mō
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 鼻子
+    pinyin: bí zi
+  - chinese: 。
+    pinyin: ''
+  english: Don't touch my nose.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: I like to eat apples.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 大
+    pinyin: dà
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: He bought a big apple.
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 箱
+    pinyin: xiāng
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: Mom bought me a box of apples.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 甜
+    pinyin: tián
+  - chinese: 。
+    pinyin: ''
+  english: This apple is very sweet.
+
+- segments:
+  - chinese: 孩子们
+    pinyin: hái zi men
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: The children are eating apples.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 比
+    pinyin: bǐ
+  - chinese: 她
+    pinyin: tā
+  - chinese: 高
+    pinyin: gāo
+  - chinese: 。
+    pinyin: ''
+  english: I am taller than her.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 比
+    pinyin: bǐ
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 大
+    pinyin: dà
+  - chinese: 。
+    pinyin: ''
+  english: This apple is bigger than that apple.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 比
+    pinyin: bǐ
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 聪明
+    pinyin: cōng ming
+  - chinese: 。
+    pinyin: ''
+  english: He is smarter than me.
+
+- segments:
+  - chinese: 运动
+    pinyin: yùn dòng
+  - chinese: 比
+    pinyin: bǐ
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电视
+    pinyin: diàn shì
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: Exercise is better than watching TV.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 比
+    pinyin: bǐ
+  - chinese: 他
+    pinyin: tā
+  - chinese: 早
+    pinyin: zǎo
+  - chinese: 到
+    pinyin: dào
+  - chinese: 十
+    pinyin: shí
+  - chinese: 分钟
+    pinyin: fēn zhōng
+  - chinese: 。
+    pinyin: ''
+  english: I arrived ten minutes earlier than him.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 。
+    pinyin: ''
+  english: I like my job.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 挑战
+    pinyin: tiǎo zhàn
+  - chinese: 性
+    pinyin: xìng
+  - chinese: 。
+    pinyin: ''
+  english: Your job is very challenging.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 父母
+    pinyin: fù mǔ
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 。
+    pinyin: ''
+  english: Both my parents work.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 累
+    pinyin: lèi
+  - chinese: 人
+    pinyin: rén
+  - chinese: 。
+    pinyin: ''
+  english: This job is very tiring.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 稳定
+    pinyin: wěn dìng
+  - chinese: 。
+    pinyin: ''
+  english: Her job is very stable.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 中国菜
+    pinyin: Zhōng guó cài
+  - chinese: 。
+    pinyin: ''
+  english: I like to eat Chinese food.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 去
+    pinyin: qù
+  - chinese: 图书馆
+    pinyin: tú shū guǎn
+  - chinese: 。
+    pinyin: ''
+  english: I go to the library every day.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 名
+    pinyin: míng
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 。
+    pinyin: ''
+  english: I am a student.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 信任
+    pinyin: xìn rèn
+  - chinese: 他
+    pinyin: tā
+  - chinese: 。
+    pinyin: ''
+  english: He is my friend, I trust him.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 又
+    pinyin: yòu
+  - chinese: 高
+    pinyin: gāo
+  - chinese: 又
+    pinyin: yòu
+  - chinese: 帅
+    pinyin: shuài
+  - chinese: 。
+    pinyin: ''
+  english: He is tall and handsome.
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 又
+    pinyin: yòu
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 又
+    pinyin: yòu
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: 的
+    pinyin: de
+  - chinese: 一
+    pinyin: yī
+  - chinese: 天
+    pinyin: tiān
+  - chinese: 。
+    pinyin: ''
+  english: Yesterday was a cold and rainy day.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 又
+    pinyin: yòu
+  - chinese: 饿
+    pinyin: è
+  - chinese: 又
+    pinyin: yòu
+  - chinese: 累
+    pinyin: lèi
+  - chinese: 。
+    pinyin: ''
+  english: I am both hungry and tired.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 又
+    pinyin: yòu
+  - chinese: 简单
+    pinyin: jiǎn dān
+  - chinese: 又
+    pinyin: yòu
+  - chinese: 容易
+    pinyin: róng yì
+  - chinese: 。
+    pinyin: ''
+  english: This question is both simple and easy.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 又
+    pinyin: yòu
+  - chinese: 努力
+    pinyin: nǔ lì
+  - chinese: 又
+    pinyin: yòu
+  - chinese: 聪明
+    pinyin: cōng ming
+  - chinese: 的
+    pinyin: de
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 。
+    pinyin: ''
+  english: He is a hardworking and intelligent student.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 是
+    pinyin: shì
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 。
+    pinyin: ''
+  english: We are friends.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: 。
+    pinyin: ''
+  english: We eat together.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 去
+    pinyin: qù
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 。
+    pinyin: ''
+  english: We go to the park to play.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 汉语
+    pinyin: Hàn yǔ
+  - chinese: 。
+    pinyin: ''
+  english: We study Chinese.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 去
+    pinyin: qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: We go watch a movie.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 。
+    pinyin: ''
+  english: They are my friends.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 。
+    pinyin: ''
+  english: They study at school.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 打
+    pinyin: dǎ
+  - chinese: 篮球
+    pinyin: lán qiú
+  - chinese: 。
+    pinyin: ''
+  english: They like playing basketball.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 人
+    pinyin: rén
+  - chinese: 。
+    pinyin: ''
+  english: They are a family.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 。
+    pinyin: ''
+  english: They travel together.
+
+- segments:
+  - chinese: 你们
+    pinyin: nǐ men
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: How are you all?
+
+- segments:
+  - chinese: 你们
+    pinyin: nǐ men
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 中国菜
+    pinyin: Zhōng guó cài
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you all like Chinese food?
+
+- segments:
+  - chinese: 你们
+    pinyin: nǐ men
+  - chinese: 是
+    pinyin: shì
+  - chinese: 哪
+    pinyin: nǎ
+  - chinese: 国
+    pinyin: guó
+  - chinese: 人
+    pinyin: rén
+  - chinese: ？
+    pinyin: ''
+  english: What country are you all from?
+
+- segments:
+  - chinese: 你们
+    pinyin: nǐ men
+  - chinese: 的
+    pinyin: de
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 。
+    pinyin: ''
+  english: Your rooms are very beautiful.
+
+- segments:
+  - chinese: 你们
+    pinyin: nǐ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: ？
+    pinyin: ''
+  english: Where are you all studying?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好吃
+    pinyin: hǎo chī
+  - chinese: 。
+    pinyin: ''
+  english: This apple is delicious.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: This is my book.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 照片
+    pinyin: zhào piàn
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 美
+    pinyin: měi
+  - chinese: 。
+    pinyin: ''
+  english: This photo is beautiful.
+
+- segments:
+  - chinese: 这里
+    pinyin: zhè lǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 人
+    pinyin: rén
+  - chinese: 。
+    pinyin: ''
+  english: There are many people here.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 支
+    pinyin: zhī
+  - chinese: 笔
+    pinyin: bǐ
+  - chinese: 是
+    pinyin: shì
+  - chinese: 蓝
+    pinyin: lán
+  - chinese: 色
+    pinyin: sè
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: This pen is blue.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: That is a book.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 男孩
+    pinyin: nán hái
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 高
+    pinyin: gāo
+  - chinese: 。
+    pinyin: ''
+  english: That boy is tall.
+
+- segments:
+  - chinese: 那个
+    pinyin: nà ge
+  - chinese: 地方
+    pinyin: dì fāng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 美
+    pinyin: měi
+  - chinese: 。
+    pinyin: ''
+  english: That place is beautiful.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 些
+    pinyin: xiē
+  - chinese: 花
+    pinyin: huā
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 。
+    pinyin: ''
+  english: Those flowers are beautiful.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 样
+    pinyin: yàng
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 是
+    pinyin: shì
+  - chinese: 不对
+    pinyin: bù duì
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: That way of doing is not right.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 哪
+    pinyin: nǎ
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: ？
+    pinyin: ''
+  english: Which book do you need?
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 去
+    pinyin: qù
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: ？
+    pinyin: ''
+  english: Where should we go to eat?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 哪个
+    pinyin: nǎ ge
+  - chinese: 国家
+    pinyin: guó jiā
+  - chinese: 的
+    pinyin: de
+  - chinese: 国旗
+    pinyin: guó qí
+  - chinese: ？
+    pinyin: ''
+  english: Which country's flag is this?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 哪儿
+    pinyin: nǎ r
+  - chinese: 度假
+    pinyin: dù jià
+  - chinese: 了
+    pinyin: le
+  - chinese: ？
+    pinyin: ''
+  english: Where did you go for vacation?
+
+- segments:
+  - chinese: 哪
+    pinyin: nǎ
+  - chinese: 条
+    pinyin: tiáo
+  - chinese: 路
+    pinyin: lù
+  - chinese: 通往
+    pinyin: tōng wǎng
+  - chinese: 火车站
+    pinyin: huǒ chē zhàn
+  - chinese: ？
+    pinyin: ''
+  english: Which road leads to the train station?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 多少
+    pinyin: duō shao
+  - chinese: 人
+    pinyin: rén
+  - chinese: ？
+    pinyin: ''
+  english: How many people are in your family?
+
+- segments:
+  - chinese: 天上
+    pinyin: tiān shàng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 多少
+    pinyin: duō shao
+  - chinese: 星星
+    pinyin: xīng xing
+  - chinese: ？
+    pinyin: ''
+  english: How many stars are in the sky?
+
+- segments:
+  - chinese: 请问
+    pinyin: qǐng wèn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 多少
+    pinyin: duō shao
+  - chinese: 钱
+    pinyin: qián
+  - chinese: ？
+    pinyin: ''
+  english: Excuse me, how much does this clothing cost?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 他
+    pinyin: tā
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 多少
+    pinyin: duō shao
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 。
+    pinyin: ''
+  english: I don't know how many friends he has.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 多少
+    pinyin: duō shao
+  - chinese: 页
+    pinyin: yè
+  - chinese: ？
+    pinyin: ''
+  english: How many pages are there in this book?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 了
+    pinyin: le
+  - chinese: ？
+    pinyin: ''
+  english: What's wrong with you?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 。
+    pinyin: ''
+  english: I don't know how to say it.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 不
+    pinyin: bù
+  - chinese: 回来
+    pinyin: huí lai
+  - chinese: ？
+    pinyin: ''
+  english: Why don't you come back?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 做
+    pinyin: zuò
+  - chinese: ？
+    pinyin: ''
+  english: How do you do this?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 得到
+    pinyin: dé dào
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 消息
+    pinyin: xiāo xi
+  - chinese: 的
+    pinyin: de
+  - chinese: ？
+    pinyin: ''
+  english: How did you get this news?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 觉得
+    pinyin: jué de
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 样
+    pinyin: yàng
+  - chinese: ？
+    pinyin: ''
+  english: What do you think of this movie?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 的
+    pinyin: de
+  - chinese: 考试
+    pinyin: kǎo shì
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 样
+    pinyin: yàng
+  - chinese: ？
+    pinyin: ''
+  english: How was your exam today?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 餐厅
+    pinyin: cān tīng
+  - chinese: 的
+    pinyin: de
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 样
+    pinyin: yàng
+  - chinese: ？
+    pinyin: ''
+  english: How is the food at this restaurant?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 中文
+    pinyin: Zhōng wén
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 得
+    pinyin: de
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 样
+    pinyin: yàng
+  - chinese: ？
+    pinyin: ''
+  english: How well does he speak Chinese?
+
+- segments:
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 样
+    pinyin: yàng
+  - chinese: ？
+    pinyin: ''
+  english: How is the weather tomorrow?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 岁
+    pinyin: suì
+  - chinese: 了
+    pinyin: le
+  - chinese: ？
+    pinyin: ''
+  english: How old are you?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 个
+    pinyin: gè
+  - chinese: 人
+    pinyin: rén
+  - chinese: 。
+    pinyin: ''
+  english: There are a few people in my family.
+
+- segments:
+  - chinese: 请问
+    pinyin: qǐng wèn
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 了
+    pinyin: le
+  - chinese: ？
+    pinyin: ''
+  english: Excuse me, what time is it?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 页
+    pinyin: yè
+  - chinese: ？
+    pinyin: ''
+  english: How many pages does this book have?
+
+- segments:
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 号
+    pinyin: hào
+  - chinese: 是
+    pinyin: shì
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 生
+    pinyin: shēng
+  - chinese: 日
+    pinyin: rì
+  - chinese: ？
+    pinyin: ''
+  english: What date is your birthday?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I have one book.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 。
+    pinyin: ''
+  english: This is a cat.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 一
+    pinyin: yī
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 。
+    pinyin: ''
+  english: I want to buy a cup of coffee.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 要
+    pinyin: yào
+  - chinese: 锻
+    pinyin: duàn
+  - chinese: 炼
+    pinyin: liàn
+  - chinese: 一
+    pinyin: yī
+  - chinese: 小
+    pinyin: xiǎo
+  - chinese: 时
+    pinyin: shí
+  - chinese: 。
+    pinyin: ''
+  english: I exercise for one hour every day.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 一
+    pinyin: yī
+  - chinese: 块
+    pinyin: kuài
+  - chinese: 蛋糕
+    pinyin: dàn gāo
+  - chinese: 。
+    pinyin: ''
+  english: I invite you to eat a piece of cake.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 兄弟
+    pinyin: xiōng dì
+  - chinese: 。
+    pinyin: ''
+  english: I have two brothers.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 百
+    pinyin: bǎi
+  - chinese: 页
+    pinyin: yè
+  - chinese: 。
+    pinyin: ''
+  english: This book has two hundred pages.
+
+- segments:
+  - chinese: 到
+    pinyin: dào
+  - chinese: 车站
+    pinyin: chē zhàn
+  - chinese: 还有
+    pinyin: hái yǒu
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 站
+    pinyin: zhàn
+  - chinese: 地
+    pinyin: dì
+  - chinese: 。
+    pinyin: ''
+  english: There are two more stops to the train station.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 签名
+    pinyin: qiān míng
+  - chinese: 。
+    pinyin: ''
+  english: I need your two signatures.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 手表
+    pinyin: shǒu biǎo
+  - chinese: 售价
+    pinyin: shòu jià
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 千
+    pinyin: qiān
+  - chinese: 元
+    pinyin: yuán
+  - chinese: 。
+    pinyin: ''
+  english: This watch is priced at two thousand yuan.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 辣
+    pinyin: là
+  - chinese: 。
+    pinyin: ''
+  english: I don't like to eat spicy food.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 不
+    pinyin: bù
+  - chinese: 贵
+    pinyin: guì
+  - chinese: 。
+    pinyin: ''
+  english: This book is not expensive.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 不
+    pinyin: bù
+  - chinese: 会
+    pinyin: huì
+  - chinese: 游泳
+    pinyin: yóu yǒng
+  - chinese: 。
+    pinyin: ''
+  english: He cannot swim.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 地方
+    pinyin: dì fāng
+  - chinese: 。
+    pinyin: ''
+  english: I don't want to go to that place.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 不
+    pinyin: bù
+  - chinese: 辣
+    pinyin: là
+  - chinese: 。
+    pinyin: ''
+  english: This dish is not spicy.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 今年
+    pinyin: jīn nián
+  - chinese: 二十
+    pinyin: èr shí
+  - chinese: 岁
+    pinyin: suì
+  - chinese: 。
+    pinyin: ''
+  english: I am twenty years old this year.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 弟弟
+    pinyin: dì di
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 岁
+    pinyin: suì
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: My younger brother is five years old.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 马上
+    pinyin: mǎ shàng
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 要
+    pinyin: yào
+  - chinese: 过
+    pinyin: guò
+  - chinese: 生日
+    pinyin: shēng rì
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 要
+    pinyin: yào
+  - chinese: 满
+    pinyin: mǎn
+  - chinese: 二十
+    pinyin: èr shí
+  - chinese: 岁
+    pinyin: suì
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: He is going to have his birthday soon and will turn twenty.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 姐姐
+    pinyin: jiě jie
+  - chinese: 比
+    pinyin: bǐ
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 大
+    pinyin: dà
+  - chinese: 三
+    pinyin: sān
+  - chinese: 岁
+    pinyin: suì
+  - chinese: 。
+    pinyin: ''
+  english: My older sister is three years older than me.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有趣
+    pinyin: yǒu qù
+  - chinese: 。
+    pinyin: ''
+  english: This book is very interesting.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 字典
+    pinyin: zì diǎn
+  - chinese: 。
+    pinyin: ''
+  english: I bought a dictionary today.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 杂志
+    pinyin: zá zhì
+  - chinese: 的
+    pinyin: de
+  - chinese: 内容
+    pinyin: nèi róng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有意思
+    pinyin: yǒu yì si
+  - chinese: 。
+    pinyin: ''
+  english: The content of this magazine is very interesting.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 图书
+    pinyin: tú shū
+  - chinese: 馆
+    pinyin: guǎn
+  - chinese: 借
+    pinyin: jiè
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 小说
+    pinyin: xiǎo shuō
+  - chinese: 。
+    pinyin: ''
+  english: He borrowed a novel from the library.
+
+- segments:
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 些
+    pinyin: xiē
+  - chinese: 人
+    pinyin: rén
+  - chinese: 不
+    pinyin: bù
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 辣
+    pinyin: là
+  - chinese: 。
+    pinyin: ''
+  english: Some people don't like spicy food.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 一些
+    pinyin: yī xiē
+  - chinese: 帮助
+    pinyin: bāng zhù
+  - chinese: 。
+    pinyin: ''
+  english: I need some help.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一些
+    pinyin: yī xiē
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 运气
+    pinyin: yùn qi
+  - chinese: 。
+    pinyin: ''
+  english: This is some good luck.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一些
+    pinyin: yī xiē
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 考虑
+    pinyin: kǎo lǜ
+  - chinese: 。
+    pinyin: ''
+  english: Please give me some time to consider.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 只有
+    pinyin: zhǐ yǒu
+  - chinese: 一些
+    pinyin: yī xiē
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 。
+    pinyin: ''
+  english: I only have some questions.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 块
+    pinyin: kuài
+  - chinese: 钱
+    pinyin: qián
+  - chinese: 。
+    pinyin: ''
+  english: This apple costs 5 yuan.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 拿
+    pinyin: ná
+  - chinese: 出
+    pinyin: chū
+  - chinese: 一
+    pinyin: yī
+  - chinese: 块
+    pinyin: kuài
+  - chinese: 巧克力
+    pinyin: qiǎo kè lì
+  - chinese: 。
+    pinyin: ''
+  english: He took out a piece of chocolate.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 锻炼
+    pinyin: duàn liàn
+  - chinese: 一
+    pinyin: yī
+  - chinese: 块
+    pinyin: kuài
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: 。
+    pinyin: ''
+  english: I exercise for an hour every day.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 块
+    pinyin: kuài
+  - chinese: 纸
+    pinyin: zhǐ
+  - chinese: 。
+    pinyin: ''
+  english: Please give me 5 pieces of paper.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 超市
+    pinyin: chāo shì
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 块
+    pinyin: kuài
+  - chinese: 肉
+    pinyin: ròu
+  - chinese: 。
+    pinyin: ''
+  english: I bought a piece of meat at the supermarket.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 。
+    pinyin: ''
+  english: I don't have time.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 兄弟
+    pinyin: xiōng dì
+  - chinese: 姐妹
+    pinyin: jiě mèi
+  - chinese: 。
+    pinyin: ''
+  english: He doesn't have any siblings.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 答案
+    pinyin: dá àn
+  - chinese: 。
+    pinyin: ''
+  english: This question has no answer.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 选择
+    pinyin: xuǎn zé
+  - chinese: 。
+    pinyin: ''
+  english: We have no choice.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 看到
+    pinyin: kàn dào
+  - chinese: 他
+    pinyin: tā
+  - chinese: 。
+    pinyin: ''
+  english: I didn't see him.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有没有
+    pinyin: yǒu méi yǒu
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 过
+    pinyin: guò
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 部
+    pinyin: bù
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: ？
+    pinyin: ''
+  english: Have you seen this movie?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有没有
+    pinyin: yǒu méi yǒu
+  - chinese: 告诉
+    pinyin: gào sù
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 要
+    pinyin: yào
+  - chinese: 开会
+    pinyin: kāi huì
+  - chinese: ？
+    pinyin: ''
+  english: Did I tell you that we have a meeting tomorrow?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有没有
+    pinyin: yǒu méi yǒu
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 过
+    pinyin: guò
+  - chinese: 饺子
+    pinyin: jiǎo zi
+  - chinese: ？
+    pinyin: ''
+  english: Have you ever eaten dumplings?
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 有没有
+    pinyin: yǒu méi yǒu
+  - chinese: 回复
+    pinyin: huí fù
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 邮件
+    pinyin: yóu jiàn
+  - chinese: ？
+    pinyin: ''
+  english: Has she replied to your email?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 高
+    pinyin: gāo
+  - chinese: 。
+    pinyin: ''
+  english: He is tall.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 。
+    pinyin: ''
+  english: She is beautiful.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hào
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 。
+    pinyin: ''
+  english: This dish is delicious.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 累
+    pinyin: lèi
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I am tired.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 高兴
+    pinyin: gāo xìng
+  - chinese: 见到
+    pinyin: jiàn dào
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 。
+    pinyin: ''
+  english: I am pleased to meet you.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 海鲜
+    pinyin: hǎi xiān
+  - chinese: 。
+    pinyin: ''
+  english: They all like to eat seafood.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 忙
+    pinyin: máng
+  - chinese: 。
+    pinyin: ''
+  english: We are all very busy.
+
+- segments:
+  - chinese: 这些
+    pinyin: zhè xiē
+  - chinese: 书
+    pinyin: shū
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有趣
+    pinyin: yǒu qù
+  - chinese: 。
+    pinyin: ''
+  english: These books are all very interesting.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 去
+    pinyin: qù
+  - chinese: 过
+    pinyin: guò
+  - chinese: 北京
+    pinyin: Běi jīng
+  - chinese: 。
+    pinyin: ''
+  english: We have all been to Beijing.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 是
+    pinyin: shì
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 。
+    pinyin: ''
+  english: They are all students.
+
+- segments:
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 太
+    pinyin: tài
+  - chinese: 热
+    pinyin: rè
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: The weather is too hot.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 太
+    pinyin: tài
+  - chinese: 难
+    pinyin: nán
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: This question is too difficult.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 太
+    pinyin: tài
+  - chinese: 高
+    pinyin: gāo
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: He is too tall.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 任务
+    pinyin: rèn wu
+  - chinese: 太
+    pinyin: tài
+  - chinese: 重
+    pinyin: zhòng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: This task is too heavy.
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 的
+    pinyin: de
+  - chinese: 晚会
+    pinyin: wǎn huì
+  - chinese: 太
+    pinyin: tài
+  - chinese: 无聊
+    pinyin: wú liáo
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: Yesterday's party was too boring.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 和
+    pinyin: hé
+  - chinese: 茶
+    pinyin: chá
+  - chinese: 。
+    pinyin: ''
+  english: I like to drink coffee and tea.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 和
+    pinyin: hé
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 是
+    pinyin: shì
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 。
+    pinyin: ''
+  english: He and I are good friends.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 和
+    pinyin: hé
+  - chinese: 爸爸
+    pinyin: bà ba
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 了
+    pinyin: le
+  - chinese: 海边
+    pinyin: hǎi biān
+  - chinese: 。
+    pinyin: ''
+  english: I went to the seaside with my parents.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 锻炼
+    pinyin: duàn liàn
+  - chinese: 身体
+    pinyin: shēn tǐ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 早上
+    pinyin: zǎo shang
+  - chinese: 和
+    pinyin: hé
+  - chinese: 晚上
+    pinyin: wǎn shang
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 去
+    pinyin: qù
+  - chinese: 健身房
+    pinyin: jiàn shēn fáng
+  - chinese: 。
+    pinyin: ''
+  english: He exercises every day and goes to the gym in the morning and evening.
+
+- segments:
+  - chinese: 妹妹
+    pinyin: mèi mei
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 狗
+    pinyin: gǒu
+  - chinese: 和
+    pinyin: hé
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 。
+    pinyin: ''
+  english: My younger sister likes dogs and cats.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 。
+    pinyin: ''
+  english: I am at school.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 不
+    pinyin: bù
+  - chinese: 在
+    pinyin: zài
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 。
+    pinyin: ''
+  english: He is not at home.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 医院
+    pinyin: yī yuàn
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 。
+    pinyin: ''
+  english: She works at the hospital.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 餐厅
+    pinyin: cān tīng
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: 。
+    pinyin: ''
+  english: We are eating in the restaurant.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 电影院
+    pinyin: diàn yǐng yuàn
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: They are watching a movie in the cinema.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: This is my book.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 是
+    pinyin: shì
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 的
+    pinyin: de
+  - chinese: 房子
+    pinyin: fáng zi
+  - chinese: 。
+    pinyin: ''
+  english: That is their house.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 是
+    pinyin: shì
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 责任
+    pinyin: zé rèn
+  - chinese: 。
+    pinyin: ''
+  english: This issue is your responsibility.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 的
+    pinyin: de
+  - chinese: 时机
+    pinyin: shí jī
+  - chinese: 。
+    pinyin: ''
+  english: This is our opportunity.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 手机
+    pinyin: shǒu jī
+  - chinese: 关
+    pinyin: guān
+  - chinese: 掉
+    pinyin: diào
+  - chinese: 。
+    pinyin: ''
+  english: Please turn off your mobile phone.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 干什么
+    pinyin: gàn shén me
+  - chinese: 呢
+    pinyin: ne
+  - chinese: ？
+    pinyin: ''
+  english: What are you doing?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 谁
+    pinyin: shéi
+  - chinese: 的
+    pinyin: de
+  - chinese: 书
+    pinyin: shū
+  - chinese: 呢
+    pinyin: ne
+  - chinese: ？
+    pinyin: ''
+  english: Whose book is this?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 颜色
+    pinyin: yán sè
+  - chinese: 呢
+    pinyin: ne
+  - chinese: ？
+    pinyin: ''
+  english: What color do you like?
+
+- segments:
+  - chinese: 去
+    pinyin: qù
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 呢
+    pinyin: ne
+  - chinese: ？
+    pinyin: ''
+  english: Where are you going to play?
+
+- segments:
+  - chinese: 现在
+    pinyin: xiàn zài
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 钟
+    pinyin: zhōng
+  - chinese: 呢
+    pinyin: ne
+  - chinese: ？
+    pinyin: ''
+  english: What time is it now?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 。
+    pinyin: ''
+  english: I study at school.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 。
+    pinyin: ''
+  english: This is my school.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 大
+    pinyin: dà
+  - chinese: 。
+    pinyin: ''
+  english: My school is big.
+
+- segments:
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 。
+    pinyin: ''
+  english: There are many students in the school.
+
+- segments:
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 。
+    pinyin: ''
+  english: I am going to school tomorrow.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 饭店
+    pinyin: fàn diàn
+  - chinese: 的
+    pinyin: de
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 。
+    pinyin: ''
+  english: The food at this restaurant is delicious.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 饭店
+    pinyin: fàn diàn
+  - chinese: 开
+    pinyin: kāi
+  - chinese: 了
+    pinyin: le
+  - chinese: 个
+    pinyin: gè
+  - chinese: 会
+    pinyin: huì
+  - chinese: 。
+    pinyin: ''
+  english: We had a meeting at the hotel.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 饭店
+    pinyin: fàn diàn
+  - chinese: 订
+    pinyin: dìng
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 。
+    pinyin: ''
+  english: We booked a room at the hotel.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 和
+    pinyin: hé
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 家人
+    pinyin: jiā rén
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 饭店
+    pinyin: fàn diàn
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 晚饭
+    pinyin: wǎn fàn
+  - chinese: 。
+    pinyin: ''
+  english: My family and I went to the restaurant to have dinner.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 饭店
+    pinyin: fàn diàn
+  - chinese: 的
+    pinyin: de
+  - chinese: 服务员
+    pinyin: fú wù yuán
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 热情
+    pinyin: rè qíng
+  - chinese: 。
+    pinyin: ''
+  english: The waiters at this restaurant are very friendly.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 。
+    pinyin: ''
+  english: I go to the store to buy things.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 卖
+    pinyin: mài
+  - chinese: 水果
+    pinyin: shuǐ guǒ
+  - chinese: 和
+    pinyin: hé
+  - chinese: 蔬菜
+    pinyin: shū cài
+  - chinese: 。
+    pinyin: ''
+  english: This store sells fruits and vegetables.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 关门
+    pinyin: guān mén
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: That store is closed today.
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 在
+    pinyin: zài
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 条
+    pinyin: tiáo
+  - chinese: 裙子
+    pinyin: qún zi
+  - chinese: 。
+    pinyin: ''
+  english: Mom bought a dress in the store.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 住
+    pinyin: zhù
+  - chinese: 的
+    pinyin: de
+  - chinese: 地方
+    pinyin: dì fang
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 。
+    pinyin: ''
+  english: There are many stores where I live.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 去
+    pinyin: qù
+  - chinese: 医院
+    pinyin: yī yuàn
+  - chinese: 看病
+    pinyin: kàn bìng
+  - chinese: 。
+    pinyin: ''
+  english: We go to the hospital to see a doctor.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 医院
+    pinyin: yī yuàn
+  - chinese: 的
+    pinyin: de
+  - chinese: 设施
+    pinyin: shè shī
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 现代化
+    pinyin: xiàn dài huà
+  - chinese: 。
+    pinyin: ''
+  english: The facilities in this hospital are very modern.
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 在
+    pinyin: zài
+  - chinese: 医院
+    pinyin: yī yuàn
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 。
+    pinyin: ''
+  english: Mom works at the hospital.
+
+- segments:
+  - chinese: 医院
+    pinyin: yī yuàn
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 病人
+    pinyin: bìng rén
+  - chinese: 。
+    pinyin: ''
+  english: There are many patients in the hospital.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 去
+    pinyin: qù
+  - chinese: 医院
+    pinyin: yī yuàn
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 了
+    pinyin: le
+  - chinese: 个
+    pinyin: gè
+  - chinese: 检查
+    pinyin: jiǎn chá
+  - chinese: 。
+    pinyin: ''
+  english: I went to the hospital for a check-up yesterday.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 火车站
+    pinyin: huǒ chē zhàn
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 票
+    pinyin: piào
+  - chinese: 。
+    pinyin: ''
+  english: I go to the train station to buy tickets.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 常常
+    pinyin: cháng cháng
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 火车
+    pinyin: huǒ chē
+  - chinese: 去
+    pinyin: qù
+  - chinese: 北京
+    pinyin: Běi jīng
+  - chinese: 。
+    pinyin: ''
+  english: I often take the train to Beijing.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 火车站
+    pinyin: huǒ chē zhàn
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 拥挤
+    pinyin: yōng jǐ
+  - chinese: 。
+    pinyin: ''
+  english: Today the train station is very crowded.
+
+- segments:
+  - chinese: 火车站
+    pinyin: huǒ chē zhàn
+  - chinese: 附近
+    pinyin: fù jìn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 餐馆
+    pinyin: cān guǎn
+  - chinese: 和
+    pinyin: hé
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 。
+    pinyin: ''
+  english: There are restaurants and shops near the train station.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 住
+    pinyin: zhù
+  - chinese: 在
+    pinyin: zài
+  - chinese: 火车站
+    pinyin: huǒ chē zhàn
+  - chinese: 附近
+    pinyin: fù jìn
+  - chinese: 。
+    pinyin: ''
+  english: I live near the train station.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 是
+    pinyin: shì
+  - chinese: 中国人
+    pinyin: Zhōng guó rén
+  - chinese: 。
+    pinyin: ''
+  english: I am Chinese.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 中国
+    pinyin: Zhōng guó
+  - chinese: 文化
+    pinyin: wén huà
+  - chinese: 。
+    pinyin: ''
+  english: He enjoys studying Chinese culture.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 去
+    pinyin: qù
+  - chinese: 过
+    pinyin: guò
+  - chinese: 中国
+    pinyin: Zhōng guó
+  - chinese: 。
+    pinyin: ''
+  english: My friend has been to China.
+
+- segments:
+  - chinese: 中国菜
+    pinyin: Zhōng guó cài
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 。
+    pinyin: ''
+  english: Chinese food tastes delicious.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 中国
+    pinyin: Zhōng guó
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 。
+    pinyin: ''
+  english: I want to travel to China.
+
+- segments:
+  - chinese: 北京
+    pinyin: Běi jīng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 中国
+    pinyin: Zhōng guó
+  - chinese: 的
+    pinyin: de
+  - chinese: 首都
+    pinyin: shǒu dū
+  - chinese: 。
+    pinyin: ''
+  english: Beijing is the capital of China.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 过
+    pinyin: guò
+  - chinese: 北京
+    pinyin: Běi jīng
+  - chinese: 。
+    pinyin: ''
+  english: I have been to Beijing.
+
+- segments:
+  - chinese: 北京
+    pinyin: Běi jīng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 名胜
+    pinyin: míng shèng
+  - chinese: 古迹
+    pinyin: gǔ jì
+  - chinese: 。
+    pinyin: ''
+  english: Beijing has many famous landmarks.
+
+- segments:
+  - chinese: 北京
+    pinyin: Běi jīng
+  - chinese: 的
+    pinyin: de
+  - chinese: 夏天
+    pinyin: xià tiān
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 热
+    pinyin: rè
+  - chinese: 。
+    pinyin: ''
+  english: Beijing's summers are very hot.
+
+- segments:
+  - chinese: 北京
+    pinyin: Běi jīng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 世界
+    pinyin: shì jiè
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 人口
+    pinyin: rén kǒu
+  - chinese: 最多
+    pinyin: zuì duō
+  - chinese: 的
+    pinyin: de
+  - chinese: 城市
+    pinyin: chéng shì
+  - chinese: 之一
+    pinyin: zhī yī
+  - chinese: 。
+    pinyin: ''
+  english: Beijing is one of the most populous cities in the world.
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 上班
+    pinyin: shàng bān
+  - chinese: 迟到
+    pinyin: chí dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I was late for work yesterday.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 杯子
+    pinyin: bēi zi
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 上面
+    pinyin: shàng miàn
+  - chinese: 。
+    pinyin: ''
+  english: Please put the cup on top.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 网上
+    pinyin: wǎng shàng
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 。
+    pinyin: ''
+  english: I bought a piece of clothing online.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 成绩
+    pinyin: chéng jì
+  - chinese: 上升
+    pinyin: shàng shēng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: His grades have improved.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 下车
+    pinyin: xià chē
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I disembarked the car.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 下
+    pinyin: xià
+  - chinese: 来
+    pinyin: lái
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 晚饭
+    pinyin: wǎn fàn
+  - chinese: 。
+    pinyin: ''
+  english: Please come down and have dinner.
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 下
+    pinyin: xià
+  - chinese: 楼梯
+    pinyin: lóu tī
+  - chinese: 摔
+    pinyin: shuāi
+  - chinese: 伤
+    pinyin: shāng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: Mom fell down the stairs and got injured.
+
+- segments:
+  - chinese: 快
+    pinyin: kuài
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: It's going to rain soon.
+
+- segments:
+  - chinese: 上班
+    pinyin: shàng bān
+  - chinese: 开车
+    pinyin: kāi chē
+  - chinese: 时
+    pinyin: shí
+  - chinese: 要
+    pinyin: yào
+  - chinese: 系
+    pinyin: xì
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 安全带
+    pinyin: ān quán dài
+  - chinese: ，
+    pinyin: ''
+  - chinese: 下班
+    pinyin: xià bān
+  - chinese: 时
+    pinyin: shí
+  - chinese: 要
+    pinyin: yào
+  - chinese: 关
+    pinyin: guān
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 门
+    pinyin: mén
+  - chinese: 窗
+    pinyin: chuāng
+  - chinese: 。
+    pinyin: ''
+  english: When driving to work, remember to fasten your seatbelt. When leaving work, make sure to close the doors and windows.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 站
+    pinyin: zhàn
+  - chinese: 在
+    pinyin: zài
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 前面
+    pinyin: qián miàn
+  - chinese: 。
+    pinyin: ''
+  english: I am standing in front of you.
+
+- segments:
+  - chinese: 那个
+    pinyin: nà ge
+  - chinese: 建筑物
+    pinyin: jiàn zhù wù
+  - chinese: 在
+    pinyin: zài
+  - chinese: 前面
+    pinyin: qián miàn
+  - chinese: 。
+    pinyin: ''
+  english: That building is in front.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 往
+    pinyin: wǎng
+  - chinese: 前面
+    pinyin: qián miàn
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 。
+    pinyin: ''
+  english: Please walk forward.
+
+- segments:
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 店
+    pinyin: diàn
+  - chinese: 在
+    pinyin: zài
+  - chinese: 路
+    pinyin: lù
+  - chinese: 的
+    pinyin: de
+  - chinese: 前面
+    pinyin: qián miàn
+  - chinese: 。
+    pinyin: ''
+  english: The coffee shop is in front of the road.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 广场
+    pinyin: guǎng chǎng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 的
+    pinyin: de
+  - chinese: 前面
+    pinyin: qián miàn
+  - chinese: 。
+    pinyin: ''
+  english: This square is in front of the park.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 站
+    pinyin: zhàn
+  - chinese: 在
+    pinyin: zài
+  - chinese: 树
+    pinyin: shù
+  - chinese: 后面
+    pinyin: hòu mian
+  - chinese: 。
+    pinyin: ''
+  english: He is standing behind the tree.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 房子
+    pinyin: fáng zi
+  - chinese: 在
+    pinyin: zài
+  - chinese: 海边
+    pinyin: hǎi biān
+  - chinese: 的
+    pinyin: de
+  - chinese: 后面
+    pinyin: hòu mian
+  - chinese: 。
+    pinyin: ''
+  english: My house is behind the beach.
+
+- segments:
+  - chinese: 那个
+    pinyin: nà ge
+  - chinese: 大楼
+    pinyin: dà lóu
+  - chinese: 的
+    pinyin: de
+  - chinese: 停车场
+    pinyin: tíng chē chǎng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 后面
+    pinyin: hòu mian
+  - chinese: 。
+    pinyin: ''
+  english: The parking lot of that building is at the back.
+
+- segments:
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 后面
+    pinyin: hòu mian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 。
+    pinyin: ''
+  english: There is a park behind the store.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 独自
+    pinyin: dú zì
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 教室
+    pinyin: jiào shì
+  - chinese: 后面
+    pinyin: hòu mian
+  - chinese: 。
+    pinyin: ''
+  english: He likes to sit alone at the back of the classroom.
+
+- segments:
+  - chinese: 书包
+    pinyin: shū bāo
+  - chinese: 里面
+    pinyin: lǐ miàn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: There is a book inside the backpack.
+
+- segments:
+  - chinese: 餐厅
+    pinyin: cān tīng
+  - chinese: 里面
+    pinyin: lǐ miàn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 客人
+    pinyin: kè rén
+  - chinese: 。
+    pinyin: ''
+  english: There are many customers inside the restaurant.
+
+- segments:
+  - chinese: 袋子
+    pinyin: dài zi
+  - chinese: 里面
+    pinyin: lǐ miàn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 水果
+    pinyin: shuǐ guǒ
+  - chinese: 。
+    pinyin: ''
+  english: There are many fruits inside the bag.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 里面
+    pinyin: lǐ miàn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 大
+    pinyin: dà
+  - chinese: 床
+    pinyin: chuáng
+  - chinese: 。
+    pinyin: ''
+  english: There is a big bed inside her room.
+
+- segments:
+  - chinese: 箱子
+    pinyin: xiāng zi
+  - chinese: 里面
+    pinyin: lǐ miàn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一些
+    pinyin: yī xiē
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 。
+    pinyin: ''
+  english: There are some clothes inside the box.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: Today the weather is very nice.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 要
+    pinyin: yào
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 。
+    pinyin: ''
+  english: I have a lot of work to do today.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 星期几
+    pinyin: xīng qī jǐ
+  - chinese: ？
+    pinyin: ''
+  english: What day is it today?
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 晚上
+    pinyin: wǎn shang
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: I am going to watch a movie tonight.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 了
+    pinyin: le
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: I had a lot of delicious food today.
+
+- segments:
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 星期三
+    pinyin: Xīng qī sān
+  - chinese: 。
+    pinyin: ''
+  english: Tomorrow is Wednesday.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 去
+    pinyin: qù
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 。
+    pinyin: ''
+  english: We are going on a trip tomorrow.
+
+- segments:
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 会
+    pinyin: huì
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: 。
+    pinyin: ''
+  english: It will rain tomorrow.
+
+- segments:
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 生日
+    pinyin: shēng rì
+  - chinese: 。
+    pinyin: ''
+  english: Tomorrow is my birthday.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 见面
+    pinyin: jiàn miàn
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Let's meet tomorrow.
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 了
+    pinyin: le
+  - chinese: 电影院
+    pinyin: diàn yǐng yuàn
+  - chinese: 。
+    pinyin: ''
+  english: Yesterday, I went to the cinema.
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 糟糕
+    pinyin: zāo gāo
+  - chinese: 。
+    pinyin: ''
+  english: The weather was terrible yesterday.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 晚上
+    pinyin: wǎn shang
+  - chinese: 没
+    pinyin: méi
+  - chinese: 睡
+    pinyin: shuì
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: I didn't sleep well last night.
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 忘
+    pinyin: wàng
+  - chinese: 了
+    pinyin: le
+  - chinese: 带
+    pinyin: dài
+  - chinese: 手机
+    pinyin: shǒu jī
+  - chinese: 。
+    pinyin: ''
+  english: I forgot to bring my phone yesterday.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 晚上
+    pinyin: wǎn shang
+  - chinese: 在
+    pinyin: zài
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电视
+    pinyin: diàn shì
+  - chinese: 。
+    pinyin: ''
+  english: I watched TV at home last night.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 上午
+    pinyin: shàng wǔ
+  - chinese: 锻炼
+    pinyin: duàn liàn
+  - chinese: 身体
+    pinyin: shēn tǐ
+  - chinese: 。
+    pinyin: ''
+  english: I like to exercise in the morning.
+
+- segments:
+  - chinese: 上午
+    pinyin: shàng wǔ
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 的
+    pinyin: de
+  - chinese: 会议
+    pinyin: huì yì
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 。
+    pinyin: ''
+  english: Nine o'clock in the morning is our meeting time.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 上午
+    pinyin: shàng wǔ
+  - chinese: 十一
+    pinyin: shí yī
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 去
+    pinyin: qù
+  - chinese: 上课
+    pinyin: shàng kè
+  - chinese: 。
+    pinyin: ''
+  english: He goes to class at eleven in the morning every day.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 在
+    pinyin: zài
+  - chinese: 上午
+    pinyin: shàng wǔ
+  - chinese: 阅读
+    pinyin: yuè dú
+  - chinese: 。
+    pinyin: ''
+  english: I like to read in the morning.
+
+- segments:
+  - chinese: 上午
+    pinyin: shàng wǔ
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 精力
+    pinyin: jīng lì
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 。
+    pinyin: ''
+  english: Morning is usually when I have the most energy.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 中午
+    pinyin: zhōng wǔ
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: 。
+    pinyin: ''
+  english: I eat lunch at noon.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 中午
+    pinyin: zhōng wǔ
+  - chinese: 来
+    pinyin: lái
+  - chinese: 。
+    pinyin: ''
+  english: He will come tomorrow at noon.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 在
+    pinyin: zài
+  - chinese: 中午
+    pinyin: zhōng wǔ
+  - chinese: 锻炼
+    pinyin: duàn liàn
+  - chinese: 身体
+    pinyin: shēn tǐ
+  - chinese: 。
+    pinyin: ''
+  english: I like to exercise during noon.
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 在
+    pinyin: zài
+  - chinese: 中午
+    pinyin: zhōng wǔ
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 了
+    pinyin: le
+  - chinese: 丰盛
+    pinyin: fēng shèng
+  - chinese: 的
+    pinyin: de
+  - chinese: 午餐
+    pinyin: wǔ cān
+  - chinese: 。
+    pinyin: ''
+  english: Mom made a delicious lunch at noon.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 中午
+    pinyin: zhōng wǔ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What do you want to eat for lunch today?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 下午
+    pinyin: xià wǔ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 开会
+    pinyin: kāi huì
+  - chinese: 。
+    pinyin: ''
+  english: I have a meeting in the afternoon.
+
+- segments:
+  - chinese: 下午
+    pinyin: xià wǔ
+  - chinese: 的
+    pinyin: de
+  - chinese: 阳光
+    pinyin: yáng guāng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 温暖
+    pinyin: wēn nuǎn
+  - chinese: 。
+    pinyin: ''
+  english: The afternoon sunlight is warm.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 下午
+    pinyin: xià wǔ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: They went to watch a movie in the afternoon.
+
+- segments:
+  - chinese: 星期五
+    pinyin: Xīng qī wǔ
+  - chinese: 的
+    pinyin: de
+  - chinese: 下午
+    pinyin: xià wǔ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 忙
+    pinyin: máng
+  - chinese: 。
+    pinyin: ''
+  english: Friday afternoon is busy.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 在
+    pinyin: zài
+  - chinese: 下午
+    pinyin: xià wǔ
+  - chinese: 散步
+    pinyin: sàn bù
+  - chinese: 。
+    pinyin: ''
+  english: I like to take a walk in the afternoon.
+
+- segments:
+  - chinese: 今
+    pinyin: jīn
+  - chinese: 年
+    pinyin: nián
+  - chinese: 是
+    pinyin: shì
+  - chinese: 兔
+    pinyin: tù
+  - chinese: 年
+    pinyin: nián
+  - chinese: 。
+    pinyin: ''
+  english: This year is the Year of the Rabbit.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 今
+    pinyin: jīn
+  - chinese: 年
+    pinyin: nián
+  - chinese: 二
+    pinyin: èr
+  - chinese: 十
+    pinyin: shí
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 岁
+    pinyin: suì
+  - chinese: 。
+    pinyin: ''
+  english: I am 25 years old this year.
+
+- segments:
+  - chinese: 明年
+    pinyin: míng nián
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 。
+    pinyin: ''
+  english: Next year, I want to go on a trip.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 去
+    pinyin: qù
+  - chinese: 年
+    pinyin: nián
+  - chinese: 的
+    pinyin: de
+  - chinese: 照
+    pinyin: zhào
+  - chinese: 片
+    pinyin: piàn
+  - chinese: 。
+    pinyin: ''
+  english: This is a photo from last year.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 已经
+    pinyin: yǐ jīng
+  - chinese: 三
+    pinyin: sān
+  - chinese: 年
+    pinyin: nián
+  - chinese: 没
+    pinyin: méi
+  - chinese: 回来
+    pinyin: huí lai
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: She hasn't come back for three years.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 十
+    pinyin: shí
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 一
+    pinyin: yī
+  - chinese: 日
+    pinyin: rì
+  - chinese: 。
+    pinyin: ''
+  english: Today is October 1st.
+
+- segments:
+  - chinese: 月亮
+    pinyin: yuè liang
+  - chinese: 在
+    pinyin: zài
+  - chinese: 夜空
+    pinyin: yè kōng
+  - chinese: 中
+    pinyin: zhōng
+  - chinese: 闪烁
+    pinyin: shǎn shuò
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 。
+    pinyin: ''
+  english: The moon sparkles in the night sky.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 每
+    pinyin: měi
+  - chinese: 个
+    pinyin: gè
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 收
+    pinyin: shōu
+  - chinese: 到
+    pinyin: dào
+  - chinese: 工
+    pinyin: gōng
+  - chinese: 资
+    pinyin: zī
+  - chinese: 。
+    pinyin: ''
+  english: He receives his salary every month.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 的
+    pinyin: de
+  - chinese: 账
+    pinyin: zhàng
+  - chinese: 单
+    pinyin: dān
+  - chinese: 还
+    pinyin: hái
+  - chinese: 没
+    pinyin: méi
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 寄
+    pinyin: jì
+  - chinese: 到
+    pinyin: dào
+  - chinese: 。
+    pinyin: ''
+  english: The bill for this month hasn't arrived yet.
+
+- segments:
+  - chinese: 请问
+    pinyin: qǐng wèn
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 生
+    pinyin: shēng
+  - chinese: 日
+    pinyin: rì
+  - chinese: 是
+    pinyin: shì
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 号
+    pinyin: hào
+  - chinese: ？
+    pinyin: ''
+  english: May I ask on which month and day is your birthday?
+
+- segments:
+  - chinese: 星期一
+    pinyin: Xīng qī yī
+  - chinese: 是
+    pinyin: shì
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 日
+    pinyin: rì
+  - chinese: 。
+    pinyin: ''
+  english: Monday is a workday.
+
+- segments:
+  - chinese: 周末
+    pinyin: zhōu mò
+  - chinese: 是
+    pinyin: shì
+  - chinese: 星期六
+    pinyin: Xīng qī liù
+  - chinese: 和
+    pinyin: hé
+  - chinese: 星期天
+    pinyin: Xīng qī tiān
+  - chinese: 。
+    pinyin: ''
+  english: The weekend is Saturday and Sunday.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 星期五
+    pinyin: Xīng qī wǔ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: We are going to the movies on Friday.
+
+- segments:
+  - chinese: 下
+    pinyin: xià
+  - chinese: 个
+    pinyin: gè
+  - chinese: 星期
+    pinyin: xīng qī
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 。
+    pinyin: ''
+  english: I am going on a trip next week.
+
+- segments:
+  - chinese: 星期三
+    pinyin: Xīng qī sān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 忙
+    pinyin: máng
+  - chinese: 的
+    pinyin: de
+  - chinese: 一
+    pinyin: yī
+  - chinese: 天
+    pinyin: tiān
+  - chinese: 。
+    pinyin: ''
+  english: Wednesday is my busiest day.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 。
+    pinyin: ''
+  english: Please help me order dishes.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 一
+    pinyin: yī
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 。
+    pinyin: ''
+  english: I would like to order a cup of coffee.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 对
+    pinyin: duì
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一点
+    pinyin: yī diǎn
+  - chinese: 疑问
+    pinyin: yí wèn
+  - chinese: 。
+    pinyin: ''
+  english: I have a little doubt about this question.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 建
+    pinyin: jiàn
+  - chinese: 议
+    pinyin: yì
+  - chinese: 。
+    pinyin: ''
+  english: Please give me some advice.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 明白
+    pinyin: míng bai
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 的
+    pinyin: de
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 。
+    pinyin: ''
+  english: I don't understand the point you're making.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 等
+    pinyin: děng
+  - chinese: 十
+    pinyin: shí
+  - chinese: 分钟
+    pinyin: fēn zhōng
+  - chinese: 。
+    pinyin: ''
+  english: I have to wait for ten minutes.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 百
+    pinyin: bǎi
+  - chinese: 二十
+    pinyin: èr shí
+  - chinese: 分钟
+    pinyin: fēn zhōng
+  - chinese: 。
+    pinyin: ''
+  english: This movie is 120 minutes long.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 等
+    pinyin: děng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 分钟
+    pinyin: fēn zhōng
+  - chinese: 。
+    pinyin: ''
+  english: Please wait for me for five minutes.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 分钟
+    pinyin: fēn zhōng
+  - chinese: 内
+    pinyin: nèi
+  - chinese: 完成
+    pinyin: wán chéng
+  - chinese: 了
+    pinyin: le
+  - chinese: 任务
+    pinyin: rèn wu
+  - chinese: 。
+    pinyin: ''
+  english: He completed the task within five minutes.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 早上
+    pinyin: zǎo shang
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 睡
+    pinyin: shuì
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: ，
+    pinyin: ''
+  - chinese: 但
+    pinyin: dàn
+  - chinese: 还是
+    pinyin: hái shi
+  - chinese: 迟到
+    pinyin: chí dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 十
+    pinyin: shí
+  - chinese: 分钟
+    pinyin: fēn zhōng
+  - chinese: 。
+    pinyin: ''
+  english: I slept for an hour this morning, but still arrived ten minutes late.
+
+- segments:
+  - chinese: 现在
+    pinyin: xiàn zài
+  - chinese: 是
+    pinyin: shì
+  - chinese: 晚上
+    pinyin: wǎn shang
+  - chinese: 八
+    pinyin: bā
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 。
+    pinyin: ''
+  english: It is eight o'clock in the evening now.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 现在
+    pinyin: xiàn zài
+  - chinese: 在
+    pinyin: zài
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 。
+    pinyin: ''
+  english: I am now at school.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 现在
+    pinyin: xiàn zài
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪
+    pinyin: nǎ
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: ？
+    pinyin: ''
+  english: Where are you working now?
+
+- segments:
+  - chinese: 现在
+    pinyin: xiàn zài
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 去
+    pinyin: qù
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Let's go eat now.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 现在
+    pinyin: xiàn zài
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 忙
+    pinyin: máng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不能
+    pinyin: bù néng
+  - chinese: 和
+    pinyin: hé
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 聊天
+    pinyin: liáo tiān
+  - chinese: 。
+    pinyin: ''
+  english: He is busy now and can't chat with you.
+
+- segments:
+  - chinese: 早上
+    pinyin: zǎo shang
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 。
+    pinyin: ''
+  english: Morning is my favorite time.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 夏天
+    pinyin: xià tiān
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 去
+    pinyin: qù
+  - chinese: 海滩
+    pinyin: hǎi tān
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 。
+    pinyin: ''
+  english: We went to the beach during the summer.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 放学
+    pinyin: fàng xué
+  - chinese: 之后
+    pinyin: zhī hòu
+  - chinese: 会
+    pinyin: huì
+  - chinese: 去
+    pinyin: qù
+  - chinese: 图书馆
+    pinyin: tú shū guǎn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 在
+    pinyin: zài
+  - chinese: 那里
+    pinyin: nà li
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: 。
+    pinyin: ''
+  english: After school, I will go to the library and study there for an hour.
+
+- segments:
+  - chinese: 在
+    pinyin: zài
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 孩子
+    pinyin: hái zi
+  - chinese: 小
+    pinyin: xiǎo
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 他
+    pinyin: tā
+  - chinese: 读
+    pinyin: dú
+  - chinese: 个
+    pinyin: gè
+  - chinese: 故事
+    pinyin: gù shi
+  - chinese: 。
+    pinyin: ''
+  english: When my child was young, I used to read him a story every day.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 爸爸
+    pinyin: bà ba
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 高
+    pinyin: gāo
+  - chinese: 。
+    pinyin: ''
+  english: My father is tall.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 爸爸
+    pinyin: bà ba
+  - chinese: 是
+    pinyin: shì
+  - chinese: 医生
+    pinyin: yī shēng
+  - chinese: 。
+    pinyin: ''
+  english: My father is a doctor.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 爸爸
+    pinyin: bà ba
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 开车
+    pinyin: kāi chē
+  - chinese: 上班
+    pinyin: shàng bān
+  - chinese: 。
+    pinyin: ''
+  english: My father drives to work every day.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 爸爸
+    pinyin: bà ba
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 足球
+    pinyin: zú qiú
+  - chinese: 比赛
+    pinyin: bǐ sài
+  - chinese: 。
+    pinyin: ''
+  english: My father likes to watch soccer games.
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 晚上
+    pinyin: wǎn shang
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 和
+    pinyin: hé
+  - chinese: 爸爸
+    pinyin: bà ba
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 散步
+    pinyin: sàn bù
+  - chinese: 。
+    pinyin: ''
+  english: Yesterday evening, I went for a walk with my father.
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 顿
+    pinyin: dùn
+  - chinese: 丰盛
+    pinyin: fēng shèng
+  - chinese: 的
+    pinyin: de
+  - chinese: 晚饭
+    pinyin: wǎn fàn
+  - chinese: 。
+    pinyin: ''
+  english: Mom made a delicious dinner.
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 总
+    pinyin: zǒng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 关心
+    pinyin: guān xīn
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 。
+    pinyin: ''
+  english: Mom always cares about my study.
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 。
+    pinyin: ''
+  english: Mom bought me a new dress.
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 为了
+    pinyin: wèi le
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 放弃
+    pinyin: fàng qì
+  - chinese: 了
+    pinyin: le
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 。
+    pinyin: ''
+  english: Mom gave up a lot for me.
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 最好
+    pinyin: zuì hǎo
+  - chinese: 的
+    pinyin: de
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 。
+    pinyin: ''
+  english: Mom is my best friend.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 儿子
+    pinyin: ér zi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 聪明
+    pinyin: cōng ming
+  - chinese: 。
+    pinyin: ''
+  english: His son is very clever.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 儿子
+    pinyin: ér zi
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 画画
+    pinyin: huà huà
+  - chinese: 。
+    pinyin: ''
+  english: My son likes to draw.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 儿子
+    pinyin: ér zi
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 十
+    pinyin: shí
+  - chinese: 岁
+    pinyin: suì
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: His son is turning ten this month.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 儿子
+    pinyin: ér zi
+  - chinese: 是
+    pinyin: shì
+  - chinese: 个
+    pinyin: gè
+  - chinese: 刚
+    pinyin: gāng
+  - chinese: 出生
+    pinyin: chū shēng
+  - chinese: 的
+    pinyin: de
+  - chinese: 婴儿
+    pinyin: yīng ér
+  - chinese: 。
+    pinyin: ''
+  english: Her son is a newborn baby.
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 带
+    pinyin: dài
+  - chinese: 儿子
+    pinyin: ér zi
+  - chinese: 去
+    pinyin: qù
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: Yesterday, I took my son to the park to play.
+
+- segments:
+  - chinese: 女儿
+    pinyin: nǚ ér
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 。
+    pinyin: ''
+  english: The daughter is very beautiful.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 的
+    pinyin: de
+  - chinese: 女儿
+    pinyin: nǚ ér
+  - chinese: 。
+    pinyin: ''
+  english: She is my mother's daughter.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 女儿
+    pinyin: nǚ ér
+  - chinese: 和
+    pinyin: hé
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 儿子
+    pinyin: ér zi
+  - chinese: 。
+    pinyin: ''
+  english: I have a daughter and a son.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 独生
+    pinyin: dú shēng
+  - chinese: 女儿
+    pinyin: nǚ ér
+  - chinese: 。
+    pinyin: ''
+  english: She is the only daughter.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 女儿
+    pinyin: nǚ ér
+  - chinese: 非常
+    pinyin: fēi cháng
+  - chinese: 聪明
+    pinyin: cōng ming
+  - chinese: 。
+    pinyin: ''
+  english: My daughter is very smart.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 。
+    pinyin: ''
+  english: I like my teacher.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 位
+    pinyin: wèi
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 教
+    pinyin: jiāo
+  - chinese: 得
+    pinyin: de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: This teacher teaches very well.
+
+- segments:
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: ，
+    pinyin: ''
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 您
+    pinyin: nín
+  - chinese: 再
+    pinyin: zài
+  - chinese: 解释
+    pinyin: jiě shì
+  - chinese: 一遍
+    pinyin: yī biàn
+  - chinese: 。
+    pinyin: ''
+  english: Teacher, please explain again.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 的
+    pinyin: de
+  - chinese: 数学
+    pinyin: shù xué
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 严格
+    pinyin: yán gé
+  - chinese: 。
+    pinyin: ''
+  english: Our math teacher is very strict.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 希望
+    pinyin: xī wàng
+  - chinese: 将来
+    pinyin: jiāng lái
+  - chinese: 能
+    pinyin: néng
+  - chinese: 成为
+    pinyin: chéng wéi
+  - chinese: 一
+    pinyin: yī
+  - chinese: 名
+    pinyin: míng
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 。
+    pinyin: ''
+  english: I hope to become a teacher in the future.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 位
+    pinyin: wèi
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 。
+    pinyin: ''
+  english: She is a good student.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 班
+    pinyin: bān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 三十
+    pinyin: sān shí
+  - chinese: 个
+    pinyin: gè
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 。
+    pinyin: ''
+  english: This class has thirty students.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 是
+    pinyin: shì
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 。
+    pinyin: ''
+  english: All of my friends are students.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 学
+    pinyin: xué
+  - chinese: 生活
+    pinyin: shēng huó
+  - chinese: 。
+    pinyin: ''
+  english: We study and live at school.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 同学
+    pinyin: tóng xué
+  - chinese: 。
+    pinyin: ''
+  english: This is my classmate.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 是
+    pinyin: shì
+  - chinese: 同学
+    pinyin: tóng xué
+  - chinese: 。
+    pinyin: ''
+  english: We are classmates.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 同学
+    pinyin: tóng xué
+  - chinese: 。
+    pinyin: ''
+  english: He is my classmate.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 是
+    pinyin: shì
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 也
+    pinyin: yě
+  - chinese: 是
+    pinyin: shì
+  - chinese: 同学
+    pinyin: tóng xué
+  - chinese: 。
+    pinyin: ''
+  english: We are good friends and also classmates.
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 和
+    pinyin: hé
+  - chinese: 同学
+    pinyin: tóng xué
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 图书馆
+    pinyin: tú shū guǎn
+  - chinese: 。
+    pinyin: ''
+  english: Yesterday I went to the library with my classmate.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 。
+    pinyin: ''
+  english: I have many friends.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 和
+    pinyin: hé
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: I go to the movies with my friends.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好笑
+    pinyin: hǎo xiào
+  - chinese: 。
+    pinyin: ''
+  english: My friend is very funny.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 善良
+    pinyin: shàn liáng
+  - chinese: 。
+    pinyin: ''
+  english: My friend is very kind.
+
+- segments:
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 之间
+    pinyin: zhī jiān
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 互相
+    pinyin: hù xiāng
+  - chinese: 帮助
+    pinyin: bāng zhù
+  - chinese: 。
+    pinyin: ''
+  english: Friends should help each other.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 位
+    pinyin: wèi
+  - chinese: 医生
+    pinyin: yī shēng
+  - chinese: 。
+    pinyin: ''
+  english: He is a doctor.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 弟弟
+    pinyin: dì di
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 成为
+    pinyin: chéng wéi
+  - chinese: 一
+    pinyin: yī
+  - chinese: 名
+    pinyin: míng
+  - chinese: 医生
+    pinyin: yī shēng
+  - chinese: 。
+    pinyin: ''
+  english: My younger brother wants to become a doctor.
+
+- segments:
+  - chinese: 医生
+    pinyin: yī shēng
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 在
+    pinyin: zài
+  - chinese: 救
+    pinyin: jiù
+  - chinese: 助
+    pinyin: zhù
+  - chinese: 病人
+    pinyin: bìng rén
+  - chinese: 的
+    pinyin: de
+  - chinese: 生命
+    pinyin: shēng mìng
+  - chinese: 。
+    pinyin: ''
+  english: Doctors save lives every day.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 尊重
+    pinyin: zūn zhòng
+  - chinese: 医生
+    pinyin: yī shēng
+  - chinese: 的
+    pinyin: de
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 。
+    pinyin: ''
+  english: We should respect the work of doctors.
+
+- segments:
+  - chinese: 别
+    pinyin: bié
+  - chinese: 担
+    pinyin: dān
+  - chinese: 心
+    pinyin: xīn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 医生
+    pinyin: yī shēng
+  - chinese: 会
+    pinyin: huì
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: Don't worry, the doctor will help you.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 位
+    pinyin: wèi
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: 。
+    pinyin: ''
+  english: He is a gentleman.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 位
+    pinyin: wèi
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 等
+    pinyin: děng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 。
+    pinyin: ''
+  english: This gentleman is waiting for you.
+
+- segments:
+  - chinese: 面试
+    pinyin: miàn shì
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 叫
+    pinyin: jiào
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: 。
+    pinyin: ''
+  english: During the interview, please call me Sir.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 。
+    pinyin: ''
+  english: That gentleman is my teacher.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 餐厅
+    pinyin: cān tīng
+  - chinese: 的
+    pinyin: de
+  - chinese: 服务员
+    pinyin: fú wù yuán
+  - chinese: 对待
+    pinyin: duì dài
+  - chinese: 每
+    pinyin: měi
+  - chinese: 位
+    pinyin: wèi
+  - chinese: 顾客
+    pinyin: gù kè
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有礼貌
+    pinyin: yǒu lǐ mào
+  - chinese: ，
+    pinyin: ''
+  - chinese: 非常
+    pinyin: fēi cháng
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: 。
+    pinyin: ''
+  english: The waiter in this restaurant treats every customer very politely, very gentlemanly.
+
+- segments:
+  - chinese: 小姐
+    pinyin: xiǎo jie
+  - chinese: ，
+    pinyin: ''
+  - chinese: 请问
+    pinyin: qǐng wèn
+  - chinese: 洗手间
+    pinyin: xǐ shǒu jiān
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: ？
+    pinyin: ''
+  english: Excuse me miss, where is the restroom?
+
+- segments:
+  - chinese: 那个
+    pinyin: nà ge
+  - chinese: 小姐
+    pinyin: xiǎo jie
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 。
+    pinyin: ''
+  english: That lady is my friend.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 位
+    pinyin: wèi
+  - chinese: 小姐
+    pinyin: xiǎo jie
+  - chinese: ，
+    pinyin: ''
+  - chinese: 请问
+    pinyin: qǐng wèn
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 帮助
+    pinyin: bāng zhù
+  - chinese: ？
+    pinyin: ''
+  english: Miss, may I help you with something?
+
+- segments:
+  - chinese: 那个
+    pinyin: nà ge
+  - chinese: 小姐
+    pinyin: xiǎo jie
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 友好
+    pinyin: yǒu hǎo
+  - chinese: 。
+    pinyin: ''
+  english: That young lady is very friendly.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 辆
+    pinyin: liàng
+  - chinese: 出租车
+    pinyin: chū zū chē
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 等
+    pinyin: děng
+  - chinese: 一下
+    pinyin: yī xià
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 了
+    pinyin: le
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 。
+    pinyin: ''
+  english: Please wait a moment for this taxi, we will leave once we get on.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 。
+    pinyin: ''
+  english: This clothing is very beautiful.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 穿
+    pinyin: chuān
+  - chinese: 舒服
+    pinyin: shū fu
+  - chinese: 的
+    pinyin: de
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 。
+    pinyin: ''
+  english: I like to wear comfortable clothing.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 。
+    pinyin: ''
+  english: She bought a new piece of clothing.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 洗
+    pinyin: xǐ
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: All of my clothes are washed.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 不同
+    pinyin: bù tóng
+  - chinese: 类型
+    pinyin: lèi xíng
+  - chinese: 的
+    pinyin: de
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 。
+    pinyin: ''
+  english: This store has many different types of clothing.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 杯子
+    pinyin: bēi zi
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 。
+    pinyin: ''
+  english: There is water in this cup.
+
+- segments:
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 八
+    pinyin: bā
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 对
+    pinyin: duì
+  - chinese: 身体
+    pinyin: shēn tǐ
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: Drinking eight glasses of water every day is good for your health.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 渴
+    pinyin: kě
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 想要
+    pinyin: xiǎng yào
+  - chinese: 一
+    pinyin: yī
+  - chinese: 瓶
+    pinyin: píng
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 。
+    pinyin: ''
+  english: I'm thirsty and I want a bottle of water.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 河
+    pinyin: hé
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 清澈
+    pinyin: qīng chè
+  - chinese: 。
+    pinyin: ''
+  english: The water in this river is very clear.
+
+- segments:
+  - chinese: 不要
+    pinyin: bù yào
+  - chinese: 浪费
+    pinyin: làng fèi
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 资源
+    pinyin: zī yuán
+  - chinese: ，
+    pinyin: ''
+  - chinese: 要
+    pinyin: yào
+  - chinese: 节约
+    pinyin: jié yuē
+  - chinese: 用
+    pinyin: yòng
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 。
+    pinyin: ''
+  english: Don't waste water resources, save water.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 蔬菜
+    pinyin: shū cài
+  - chinese: 。
+    pinyin: ''
+  english: I like to eat vegetables.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 饭馆
+    pinyin: fàn guǎn
+  - chinese: 的
+    pinyin: de
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hào
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 。
+    pinyin: ''
+  english: The food at this restaurant is delicious.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 。
+    pinyin: ''
+  english: She is cooking.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 市场
+    pinyin: shì chǎng
+  - chinese: 。
+    pinyin: ''
+  english: This is a vegetable market.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 道
+    pinyin: dào
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 是
+    pinyin: shì
+  - chinese: 他
+    pinyin: tā
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: This dish was made by him.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 米饭
+    pinyin: mǐ fàn
+  - chinese: 。
+    pinyin: ''
+  english: I like to eat rice.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 米饭
+    pinyin: mǐ fàn
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you want to eat rice?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 米饭
+    pinyin: mǐ fàn
+  - chinese: 。
+    pinyin: ''
+  english: I eat rice every day.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 碗
+    pinyin: wǎn
+  - chinese: 热
+    pinyin: rè
+  - chinese: 米饭
+    pinyin: mǐ fàn
+  - chinese: 。
+    pinyin: ''
+  english: This is a bowl of hot rice.
+
+- segments:
+  - chinese: 煮
+    pinyin: zhǔ
+  - chinese: 米饭
+    pinyin: mǐ fàn
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 多
+    pinyin: duō
+  - chinese: 长
+    pinyin: cháng
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: ？
+    pinyin: ''
+  english: How long does it take to cook rice?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 水果
+    pinyin: shuǐ guǒ
+  - chinese: 。
+    pinyin: ''
+  english: I like to eat fruit.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: This is an apple.
+
+- segments:
+  - chinese: 橙子
+    pinyin: chéng zi
+  - chinese: 是
+    pinyin: shì
+  - chinese: 柑橘
+    pinyin: gān jú
+  - chinese: 的
+    pinyin: de
+  - chinese: 一
+    pinyin: yī
+  - chinese: 种
+    pinyin: zhǒng
+  - chinese: 。
+    pinyin: ''
+  english: Oranges are a kind of citrus fruit.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 的
+    pinyin: de
+  - chinese: 水果
+    pinyin: shuǐ guǒ
+  - chinese: 是
+    pinyin: shì
+  - chinese: 草莓
+    pinyin: cǎo méi
+  - chinese: 。
+    pinyin: ''
+  english: My favorite fruit is strawberries.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 水果
+    pinyin: shuǐ guǒ
+  - chinese: 摊
+    pinyin: tān
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 多
+    pinyin: duō
+  - chinese: 种
+    pinyin: zhǒng
+  - chinese: 水果
+    pinyin: shuǐ guǒ
+  - chinese: 。
+    pinyin: ''
+  english: There are many kinds of fruits at this fruit stall.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 水果
+    pinyin: shuǐ guǒ
+  - chinese: 。
+    pinyin: ''
+  english: She eats a lot of fruits every day.
+
+- segments:
+  - chinese: 水果
+    pinyin: shuǐ guǒ
+  - chinese: 对
+    pinyin: duì
+  - chinese: 身体
+    pinyin: shēn tǐ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 益处
+    pinyin: yì chu
+  - chinese: 。
+    pinyin: ''
+  english: Fruits are very beneficial to the body.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一些
+    pinyin: yī xiē
+  - chinese: 水果
+    pinyin: shuǐ guǒ
+  - chinese: 。
+    pinyin: ''
+  english: I bought some fruits yesterday.
+
+- segments:
+  - chinese: 橘子
+    pinyin: jú zi
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 的
+    pinyin: de
+  - chinese: 水果
+    pinyin: shuǐ guǒ
+  - chinese: 之
+    pinyin: zhī
+  - chinese: 一
+    pinyin: yī
+  - chinese: 。
+    pinyin: ''
+  english: Oranges are one of my favorite fruits.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 茶
+    pinyin: chá
+  - chinese: 。
+    pinyin: ''
+  english: I like to drink tea.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一
+    pinyin: yī
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 茶
+    pinyin: chá
+  - chinese: 。
+    pinyin: ''
+  english: Please give me a cup of tea.
+
+- segments:
+  - chinese: 茶
+    pinyin: chá
+  - chinese: 的
+    pinyin: de
+  - chinese: 味道
+    pinyin: wèi dao
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 香
+    pinyin: xiāng
+  - chinese: 。
+    pinyin: ''
+  english: The taste of tea is very fragrant.
+
+- segments:
+  - chinese: 看书
+    pinyin: kàn shū
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 茶
+    pinyin: chá
+  - chinese: 能
+    pinyin: néng
+  - chinese: 放松
+    pinyin: fàng sōng
+  - chinese: 。
+    pinyin: ''
+  english: Drinking tea while reading can help relax.
+
+- segments:
+  - chinese: 一
+    pinyin: yī
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 茶
+    pinyin: chá
+  - chinese: 解渴
+    pinyin: jiě kě
+  - chinese: 。
+    pinyin: ''
+  english: A cup of tea quenches thirst.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 的
+    pinyin: de
+  - chinese: 杯子
+    pinyin: bēi zi
+  - chinese: 。
+    pinyin: ''
+  english: I bought a new cup.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 借
+    pinyin: jiè
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 杯子
+    pinyin: bēi zi
+  - chinese: 。
+    pinyin: ''
+  english: Please lend me your cup.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 杯子
+    pinyin: bēi zi
+  - chinese: 是
+    pinyin: shì
+  - chinese: 红色
+    pinyin: hóng sè
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: This cup is red.
+
+- segments:
+  - chinese: 杯子
+    pinyin: bēi zi
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 有一点
+    pinyin: yǒu yī diǎn
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 。
+    pinyin: ''
+  english: There is a little coffee in the cup.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 用
+    pinyin: yòng
+  - chinese: 了
+    pinyin: le
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 杯子
+    pinyin: bēi zi
+  - chinese: 。
+    pinyin: ''
+  english: I used two cups.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 一些
+    pinyin: yī xiē
+  - chinese: 钱
+    pinyin: qián
+  - chinese: 。
+    pinyin: ''
+  english: I need some money.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 借
+    pinyin: jiè
+  - chinese: 了
+    pinyin: le
+  - chinese: 钱
+    pinyin: qián
+  - chinese: 。
+    pinyin: ''
+  english: He lent me money today.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 银行
+    pinyin: yín háng
+  - chinese: 取
+    pinyin: qǔ
+  - chinese: 了
+    pinyin: le
+  - chinese: 一些
+    pinyin: yī xiē
+  - chinese: 钱
+    pinyin: qián
+  - chinese: 。
+    pinyin: ''
+  english: I withdrew some money from the bank.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 包
+    pinyin: bāo
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 贵
+    pinyin: guì
+  - chinese: ，
+    pinyin: ''
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 钱
+    pinyin: qián
+  - chinese: 。
+    pinyin: ''
+  english: This bag is expensive, it requires a lot of money.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 工资
+    pinyin: gōng zī
+  - chinese: 足够
+    pinyin: zú gòu
+  - chinese: 支付
+    pinyin: zhī fù
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 生活
+    pinyin: shēng huó
+  - chinese: 费用
+    pinyin: fèi yòng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: My salary is enough to cover my living expenses.
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 飞机
+    pinyin: fēi jī
+  - chinese: 去
+    pinyin: qù
+  - chinese: 北京
+    pinyin: Běi jīng
+  - chinese: 。
+    pinyin: ''
+  english: Yesterday, I took a plane to Beijing.
+
+- segments:
+  - chinese: 飞机
+    pinyin: fēi jī
+  - chinese: 在
+    pinyin: zài
+  - chinese: 天空
+    pinyin: tiān kōng
+  - chinese: 中
+    pinyin: zhōng
+  - chinese: 飞翔
+    pinyin: fēi xiáng
+  - chinese: 。
+    pinyin: ''
+  english: The airplane is flying in the sky.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 飞机票
+    pinyin: fēi jī piào
+  - chinese: 。
+    pinyin: ''
+  english: He bought an airplane ticket.
+
+- segments:
+  - chinese: 飞机
+    pinyin: fēi jī
+  - chinese: 即将
+    pinyin: jí jiāng
+  - chinese: 降落
+    pinyin: jiàng luò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 机场
+    pinyin: jī chǎng
+  - chinese: 。
+    pinyin: ''
+  english: The airplane is about to land at the airport.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 将
+    pinyin: jiāng
+  - chinese: 乘坐
+    pinyin: chéng zuò
+  - chinese: 飞机
+    pinyin: fēi jī
+  - chinese: 去
+    pinyin: qù
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 。
+    pinyin: ''
+  english: We will travel by plane.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 出租车
+    pinyin: chū zū chē
+  - chinese: 去
+    pinyin: qù
+  - chinese: 机场
+    pinyin: jī chǎng
+  - chinese: 。
+    pinyin: ''
+  english: I take a taxi to the airport.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 辆
+    pinyin: liàng
+  - chinese: 出租车
+    pinyin: chū zū chē
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 快
+    pinyin: kuài
+  - chinese: 。
+    pinyin: ''
+  english: This taxi is very fast.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 路上
+    pinyin: lù shang
+  - chinese: 打
+    pinyin: dǎ
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 辆
+    pinyin: liàng
+  - chinese: 出租车
+    pinyin: chū zū chē
+  - chinese: 。
+    pinyin: ''
+  english: We hailed a taxi on the road.
+
+- segments:
+  - chinese: 出租车
+    pinyin: chū zū chē
+  - chinese: 司机
+    pinyin: sī jī
+  - chinese: 不
+    pinyin: bù
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 那里
+    pinyin: nà li
+  - chinese: 。
+    pinyin: ''
+  english: The taxi driver doesn't know where to go.
+
+- segments:
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 出租车
+    pinyin: chū zū chē
+  - chinese: 更
+    pinyin: gèng
+  - chinese: 方便
+    pinyin: fāng biàn
+  - chinese: 一些
+    pinyin: yī xiē
+  - chinese: 。
+    pinyin: ''
+  english: Taking a taxi is more convenient.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电视
+    pinyin: diàn shì
+  - chinese: 。
+    pinyin: ''
+  english: I like to watch TV.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 晚上
+    pinyin: wǎn shang
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电视
+    pinyin: diàn shì
+  - chinese: 。
+    pinyin: ''
+  english: He watches TV every night.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 电视
+    pinyin: diàn shì
+  - chinese: 太
+    pinyin: tài
+  - chinese: 大
+    pinyin: dà
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: This TV is too big.
+
+- segments:
+  - chinese: 昨
+    pinyin: zuó
+  - chinese: 晚
+    pinyin: wǎn
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 电视
+    pinyin: diàn shì
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 部
+    pinyin: bù
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: Last night, I watched a movie on TV.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 电视
+    pinyin: diàn shì
+  - chinese: 打开
+    pinyin: dǎ kāi
+  - chinese: 。
+    pinyin: ''
+  english: Please turn on the TV.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 电脑
+    pinyin: diàn nǎo
+  - chinese: 坏
+    pinyin: huài
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: My computer is broken.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 用
+    pinyin: yòng
+  - chinese: 电脑
+    pinyin: diàn nǎo
+  - chinese: 写
+    pinyin: xiě
+  - chinese: 论文
+    pinyin: lùn wén
+  - chinese: 。
+    pinyin: ''
+  english: He is using the computer to write his paper.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 台
+    pinyin: tái
+  - chinese: 电脑
+    pinyin: diàn nǎo
+  - chinese: 是
+    pinyin: shì
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: This computer is newly purchased.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 用
+    pinyin: yòng
+  - chinese: 电脑
+    pinyin: diàn nǎo
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 。
+    pinyin: ''
+  english: I work on the computer every day.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 电脑
+    pinyin: diàn nǎo
+  - chinese: 游戏
+    pinyin: yóu xì
+  - chinese: 。
+    pinyin: ''
+  english: She enjoys playing computer games.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 经常
+    pinyin: jīng cháng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 电影院
+    pinyin: diàn yǐng yuàn
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: I often go to the cinema to watch movies.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 动画
+    pinyin: dòng huà
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: I like watching animated movies.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 位
+    pinyin: wèi
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 导演
+    pinyin: dǎo yǎn
+  - chinese: 。
+    pinyin: ''
+  english: He is a movie director.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 见
+    pinyin: jiàn
+  - chinese: 过
+    pinyin: guò
+  - chinese: 她
+    pinyin: tā
+  - chinese: 。
+    pinyin: ''
+  english: I have seen her in a movie.
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 晚上
+    pinyin: wǎn shang
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 部
+    pinyin: bù
+  - chinese: 经典
+    pinyin: jīng diǎn
+  - chinese: 的
+    pinyin: de
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: I watched a classic movie last night.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 的
+    pinyin: de
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: Today's weather is very good.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 关注
+    pinyin: guān zhù
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 预报
+    pinyin: yù bào
+  - chinese: 。
+    pinyin: ''
+  english: We should pay attention to the weather forecast.
+
+- segments:
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 的
+    pinyin: de
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 可能
+    pinyin: kě néng
+  - chinese: 会
+    pinyin: huì
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: 。
+    pinyin: ''
+  english: It may rain tomorrow.
+
+- segments:
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 转
+    pinyin: zhuǎn
+  - chinese: 凉
+    pinyin: liáng
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 记得
+    pinyin: jì de
+  - chinese: 穿
+    pinyin: chuān
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 外套
+    pinyin: wài tào
+  - chinese: 。
+    pinyin: ''
+  english: The weather has turned cool, remember to wear a jacket.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 城市
+    pinyin: chéng shì
+  - chinese: 的
+    pinyin: de
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 变化
+    pinyin: biàn huà
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 大
+    pinyin: dà
+  - chinese: 。
+    pinyin: ''
+  english: The weather in this city changes a lot.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 可爱
+    pinyin: kě ài
+  - chinese: 。
+    pinyin: ''
+  english: This cat is very cute.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 聪明
+    pinyin: cōng ming
+  - chinese: 。
+    pinyin: ''
+  english: That cat is very smart.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 养
+    pinyin: yǎng
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 。
+    pinyin: ''
+  english: I like to raise cats.
+
+- segments:
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 鱼
+    pinyin: yú
+  - chinese: 。
+    pinyin: ''
+  english: Cats like to eat fish.
+
+- segments:
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 睡
+    pinyin: shuì
+  - chinese: 得
+    pinyin: de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 香
+    pinyin: xiāng
+  - chinese: 。
+    pinyin: ''
+  english: The cat is sleeping soundly.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 狗
+    pinyin: gǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 可爱
+    pinyin: kě ài
+  - chinese: 。
+    pinyin: ''
+  english: This dog is very cute.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 条
+    pinyin: tiáo
+  - chinese: 街
+    pinyin: jiē
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 狗
+    pinyin: gǒu
+  - chinese: 。
+    pinyin: ''
+  english: There are many dogs on this street.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 养
+    pinyin: yǎng
+  - chinese: 狗
+    pinyin: gǒu
+  - chinese: 。
+    pinyin: ''
+  english: I like to raise dogs.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 家里
+    pinyin: jiā lǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 只
+    pinyin: zhǐ
+  - chinese: 小狗
+    pinyin: xiǎo gǒu
+  - chinese: 。
+    pinyin: ''
+  english: There is a small dog in her house.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 怕
+    pinyin: pà
+  - chinese: 狗
+    pinyin: gǒu
+  - chinese: 。
+    pinyin: ''
+  english: I am afraid of dogs.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一些
+    pinyin: yī xiē
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 。
+    pinyin: ''
+  english: I bought some things.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 。
+    pinyin: ''
+  english: This is my thing.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 收集
+    pinyin: shōu jí
+  - chinese: 各种
+    pinyin: gè zhǒng
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 。
+    pinyin: ''
+  english: She likes to collect all kinds of things.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 那个
+    pinyin: nà ge
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 。
+    pinyin: ''
+  english: Please give me that thing.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 包
+    pinyin: bāo
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 装有
+    pinyin: zhuāng yǒu
+  - chinese: 重要
+    pinyin: zhòng yào
+  - chinese: 的
+    pinyin: de
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 。
+    pinyin: ''
+  english: There are important things inside this bag.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 地方
+    pinyin: dì fang
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 人
+    pinyin: rén
+  - chinese: 。
+    pinyin: ''
+  english: There are many people in this place.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 是
+    pinyin: shì
+  - chinese: 同事
+    pinyin: tóng shì
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不是
+    pinyin: bù shì
+  - chinese: 陌生人
+    pinyin: mò shēng rén
+  - chinese: 。
+    pinyin: ''
+  english: We are colleagues, not strangers.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 城市
+    pinyin: chéng shì
+  - chinese: 的
+    pinyin: de
+  - chinese: 人口
+    pinyin: rén kǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 。
+    pinyin: ''
+  english: This city has a large population.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 婴儿
+    pinyin: yīng ér
+  - chinese: 的
+    pinyin: de
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 。
+    pinyin: ''
+  english: She is the mother of that baby.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 忘记
+    pinyin: wàng jì
+  - chinese: 了
+    pinyin: le
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 名字
+    pinyin: míng zi
+  - chinese: 。
+    pinyin: ''
+  english: She forgot my name.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 弟弟
+    pinyin: dì di
+  - chinese: 的
+    pinyin: de
+  - chinese: 名字
+    pinyin: míng zi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 特别
+    pinyin: tè bié
+  - chinese: 。
+    pinyin: ''
+  english: My younger brother's name is unique.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 名字
+    pinyin: míng zi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 难
+    pinyin: nán
+  - chinese: 发音
+    pinyin: fā yīn
+  - chinese: 。
+    pinyin: ''
+  english: Her name is difficult to pronounce.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 告诉
+    pinyin: gào sù
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 全
+    pinyin: quán
+  - chinese: 名
+    pinyin: míng
+  - chinese: 。
+    pinyin: ''
+  english: Please tell me your full name.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 改变
+    pinyin: gǎi biàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 名字
+    pinyin: míng zi
+  - chinese: 。
+    pinyin: ''
+  english: He changed his name.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I bought a new book.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 。
+    pinyin: ''
+  english: Please give me this book.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 读书
+    pinyin: dú shū
+  - chinese: 。
+    pinyin: ''
+  english: I like reading books.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有意思
+    pinyin: yǒu yì si
+  - chinese: 。
+    pinyin: ''
+  english: This book is very interesting.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 忘记
+    pinyin: wàng jì
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 书
+    pinyin: shū
+  - chinese: 带来
+    pinyin: dài lái
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I forgot to bring the book.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 汉语
+    pinyin: Hàn yǔ
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you speak Chinese?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 汉语
+    pinyin: Hàn yǔ
+  - chinese: 已经
+    pinyin: yǐ jīng
+  - chinese: 三
+    pinyin: sān
+  - chinese: 年
+    pinyin: nián
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I have been studying Chinese for three years.
+
+- segments:
+  - chinese: 汉语
+    pinyin: Hàn yǔ
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 的
+    pinyin: de
+  - chinese: 语言
+    pinyin: yǔ yán
+  - chinese: 之
+    pinyin: zhī
+  - chinese: 一
+    pinyin: yī
+  - chinese: 。
+    pinyin: ''
+  english: Chinese is one of my favorite languages.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 汉语
+    pinyin: Hàn yǔ
+  - chinese: 发音
+    pinyin: fā yīn
+  - chinese: 。
+    pinyin: ''
+  english: I am learning Chinese pronunciation.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 汉语
+    pinyin: Hàn yǔ
+  - chinese: 。
+    pinyin: ''
+  english: I am studying Chinese.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 流利
+    pinyin: liú lì
+  - chinese: 地
+    pinyin: de
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 汉语
+    pinyin: Hàn yǔ
+  - chinese: 。
+    pinyin: ''
+  english: She speaks Chinese fluently.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 汉语
+    pinyin: Hàn yǔ
+  - chinese: 歌曲
+    pinyin: gē qǔ
+  - chinese: 。
+    pinyin: ''
+  english: I like to listen to Chinese songs.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 练习
+    pinyin: liàn xí
+  - chinese: 写
+    pinyin: xiě
+  - chinese: 汉语
+    pinyin: Hàn yǔ
+  - chinese: 字
+    pinyin: zì
+  - chinese: 。
+    pinyin: ''
+  english: I am practicing writing Chinese characters.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 教
+    pinyin: jiāo
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一些
+    pinyin: yī xiē
+  - chinese: 汉语
+    pinyin: Hàn yǔ
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you teach me some Chinese?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 写
+    pinyin: xiě
+  - chinese: 字
+    pinyin: zì
+  - chinese: 。
+    pinyin: ''
+  english: I can write characters.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 字
+    pinyin: zì
+  - chinese: 。
+    pinyin: ''
+  english: This book has many characters.
+
+- segments:
+  - chinese: 孩子
+    pinyin: hái zi
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 写字
+    pinyin: xiě zì
+  - chinese: 。
+    pinyin: ''
+  english: The child is learning to write characters.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 字
+    pinyin: zì
+  - chinese: 写
+    pinyin: xiě
+  - chinese: 得
+    pinyin: de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 。
+    pinyin: ''
+  english: Her handwriting is very beautiful.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 字
+    pinyin: zì
+  - chinese: 的
+    pinyin: de
+  - chinese: 意思
+    pinyin: yì si
+  - chinese: 是
+    pinyin: shì
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What is the meaning of this character?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 大
+    pinyin: dà
+  - chinese: 。
+    pinyin: ''
+  english: This table is big.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 书
+    pinyin: shū
+  - chinese: 在
+    pinyin: zài
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 。
+    pinyin: ''
+  english: My book is on the table.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 后面
+    pinyin: hòu mian
+  - chinese: 。
+    pinyin: ''
+  english: She is sitting behind the table.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 用
+    pinyin: yòng
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 敲
+    pinyin: qiāo
+  - chinese: 了
+    pinyin: le
+  - chinese: 一下
+    pinyin: yī xià
+  - chinese: 。
+    pinyin: ''
+  english: He tapped on the table.
+
+- segments:
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: There is an apple on the table.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 椅子
+    pinyin: yǐ zi
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 。
+    pinyin: ''
+  english: I am sitting on the chair.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 椅子
+    pinyin: yǐ zi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 舒适
+    pinyin: shū shì
+  - chinese: 。
+    pinyin: ''
+  english: That chair is very comfortable.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 椅子
+    pinyin: yǐ zi
+  - chinese: 是
+    pinyin: shì
+  - chinese: 木制
+    pinyin: mù zhì
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: This chair is made of wood.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 椅子
+    pinyin: yǐ zi
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 旁边
+    pinyin: páng biān
+  - chinese: 。
+    pinyin: ''
+  english: Please place the chair next to the table.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 椅子
+    pinyin: yǐ zi
+  - chinese: 。
+    pinyin: ''
+  english: There are five chairs in this room.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 谢谢
+    pinyin: xiè xie
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 帮助
+    pinyin: bāng zhù
+  - chinese: 。
+    pinyin: ''
+  english: Thank you for your help.
+
+- segments:
+  - chinese: 谢谢
+    pinyin: xiè xie
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 礼物
+    pinyin: lǐ wù
+  - chinese: 。
+    pinyin: ''
+  english: Thank you for the gift.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 谢谢
+    pinyin: xiè xie
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 父母
+    pinyin: fù mǔ
+  - chinese: 。
+    pinyin: ''
+  english: Please thank your parents.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 谢谢
+    pinyin: xiè xie
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 邀请
+    pinyin: yāo qǐng
+  - chinese: 。
+    pinyin: ''
+  english: I want to thank you for the invitation.
+
+- segments:
+  - chinese: 谢谢
+    pinyin: xiè xie
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 关心
+    pinyin: guān xīn
+  - chinese: 。
+    pinyin: ''
+  english: Thank you for your concern.
+
+- segments:
+  - chinese: 请问
+    pinyin: qǐng wèn
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 叫
+    pinyin: jiào
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 名字
+    pinyin: míng zi
+  - chinese: ？
+    pinyin: ''
+  english: Excuse me, what is your name?
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 还
+    pinyin: huán
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 。
+    pinyin: ''
+  english: Please give me back this book.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 注意
+    pinyin: zhù yì
+  - chinese: 安全
+    pinyin: ān quán
+  - chinese: 。
+    pinyin: ''
+  english: Please pay attention to safety.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 忙
+    pinyin: máng
+  - chinese: 。
+    pinyin: ''
+  english: Please do me a favor.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 迟到
+    pinyin: chí dào
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 没关系
+    pinyin: méi guān xi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 等
+    pinyin: děng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 。
+    pinyin: ''
+  english: You're late, but it's okay, I can wait for you.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 简单
+    pinyin: jiǎn dān
+  - chinese: ，
+    pinyin: ''
+  - chinese: 没关系
+    pinyin: méi guān xi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 慢
+    pinyin: màn
+  - chinese: 慢
+    pinyin: màn
+  - chinese: 来
+    pinyin: lái
+  - chinese: 。
+    pinyin: ''
+  english: This question is easy, it's okay, take your time.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 忘
+    pinyin: wàng
+  - chinese: 了
+    pinyin: le
+  - chinese: 带
+    pinyin: dài
+  - chinese: 钱包
+    pinyin: qián bāo
+  - chinese: ，
+    pinyin: ''
+  - chinese: 没关系
+    pinyin: méi guān xi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 先
+    pinyin: xiān
+  - chinese: 付
+    pinyin: fù
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: I forgot to bring my wallet, it's okay, you can pay first.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 无聊
+    pinyin: wú liáo
+  - chinese: ，
+    pinyin: ''
+  - chinese: 没关系
+    pinyin: méi guān xi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 换
+    pinyin: huàn
+  - chinese: 一
+    pinyin: yī
+  - chinese: 部
+    pinyin: bù
+  - chinese: 。
+    pinyin: ''
+  english: This movie is boring, it's okay, we can switch to another one.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I am reading a book.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电视
+    pinyin: diàn shì
+  - chinese: 。
+    pinyin: ''
+  english: She is watching TV.
+
+- segments:
+  - chinese: 孩子们
+    pinyin: hái zi men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 演出
+    pinyin: yǎn chū
+  - chinese: 。
+    pinyin: ''
+  english: The children are watching a performance.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 电影院
+    pinyin: diàn yǐng yuàn
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: I want to go to the cinema to watch a movie.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 一下
+    pinyin: yī xià
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: Can you help me take a look at this book?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 音乐
+    pinyin: yīn yuè
+  - chinese: 。
+    pinyin: ''
+  english: I like listening to music.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 说话
+    pinyin: shuō huà
+  - chinese: 。
+    pinyin: ''
+  english: Please listen to what I'm saying.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 不
+    pinyin: bù
+  - chinese: 懂
+    pinyin: dǒng
+  - chinese: 中文
+    pinyin: Zhōng wén
+  - chinese: 。
+    pinyin: ''
+  english: I don't understand Chinese when I hear it.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 常常
+    pinyin: cháng cháng
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 唱歌
+    pinyin: chàng gē
+  - chinese: 。
+    pinyin: ''
+  english: I often listen to my mom singing.
+
+- segments:
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 在
+    pinyin: zài
+  - chinese: 教室
+    pinyin: jiào shì
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 读书
+    pinyin: dú shū
+  - chinese: 。
+    pinyin: ''
+  english: The teacher listens to the students reading in the classroom.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 善于
+    pinyin: shàn yú
+  - chinese: 说话
+    pinyin: shuō huà
+  - chinese: 。
+    pinyin: ''
+  english: He is very good at speaking.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 不要
+    pinyin: bù yào
+  - chinese: 大声
+    pinyin: dà shēng
+  - chinese: 说话
+    pinyin: shuō huà
+  - chinese: 。
+    pinyin: ''
+  english: Please don't speak loudly.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 和
+    pinyin: hé
+  - chinese: 人们
+    pinyin: rén men
+  - chinese: 说话
+    pinyin: shuō huà
+  - chinese: 。
+    pinyin: ''
+  english: He likes to talk to people.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 害羞
+    pinyin: hài xiū
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不
+    pinyin: bù
+  - chinese: 善于
+    pinyin: shàn yú
+  - chinese: 说话
+    pinyin: shuō huà
+  - chinese: 。
+    pinyin: ''
+  english: She is shy and not good at talking.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 饭桌
+    pinyin: fàn zhuō
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 说话
+    pinyin: shuō huà
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can we talk at the dining table?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 读书
+    pinyin: dú shū
+  - chinese: 。
+    pinyin: ''
+  english: I like reading books.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dū
+  - chinese: 读
+    pinyin: dú
+  - chinese: 报纸
+    pinyin: bào zhǐ
+  - chinese: 。
+    pinyin: ''
+  english: I read newspapers every day.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 读
+    pinyin: dú
+  - chinese: 。
+    pinyin: ''
+  english: This book is easy to read.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 读出
+    pinyin: dú chū
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 名字
+    pinyin: míng zi
+  - chinese: 。
+    pinyin: ''
+  english: Please read out your name.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 读
+    pinyin: dú
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 篇
+    pinyin: piān
+  - chinese: 文章
+    pinyin: wén zhāng
+  - chinese: 。
+    pinyin: ''
+  english: Let's read this article together.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 写
+    pinyin: xiě
+  - chinese: 小说
+    pinyin: xiǎo shuō
+  - chinese: 。
+    pinyin: ''
+  english: He likes to write novels.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 写
+    pinyin: xiě
+  - chinese: 日记
+    pinyin: rì jì
+  - chinese: 。
+    pinyin: ''
+  english: I write a diary every day.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 写
+    pinyin: xiě
+  - chinese: 得
+    pinyin: de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 。
+    pinyin: ''
+  english: He writes beautifully.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 黑板
+    pinyin: hēi bǎn
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 写
+    pinyin: xiě
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 字
+    pinyin: zì
+  - chinese: 。
+    pinyin: ''
+  english: She wrote a character on the blackboard.
+
+- segments:
+  - chinese: 报告
+    pinyin: bào gào
+  - chinese: 还
+    pinyin: hái
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 写
+    pinyin: xiě
+  - chinese: 完
+    pinyin: wán
+  - chinese: 。
+    pinyin: ''
+  english: The report is not written yet.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 看见
+    pinyin: kàn jiàn
+  - chinese: 一
+    pinyin: yī
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 小狗
+    pinyin: xiǎo gǒu
+  - chinese: 在
+    pinyin: zài
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 跑
+    pinyin: pǎo
+  - chinese: 。
+    pinyin: ''
+  english: I saw a little dog running in the park.
+
+- segments:
+  - chinese: 小
+    pinyin: xiǎo
+  - chinese: 明
+    pinyin: míng
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 晚上
+    pinyin: wǎn shang
+  - chinese: 没
+    pinyin: méi
+  - chinese: 看见
+    pinyin: kàn jiàn
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 回家
+    pinyin: huí jiā
+  - chinese: 。
+    pinyin: ''
+  english: Xiaoming didn't see mom coming home last night.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 一直
+    pinyin: yī zhí
+  - chinese: 在
+    pinyin: zài
+  - chinese: 看见
+    pinyin: kàn jiàn
+  - chinese: 自己
+    pinyin: zì jǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 镜子
+    pinyin: jìng zi
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 影子
+    pinyin: yǐng zi
+  - chinese: 。
+    pinyin: ''
+  english: He has been seeing his own reflection in the mirror.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 用
+    pinyin: yòng
+  - chinese: 望远镜
+    pinyin: wàng yuǎn jìng
+  - chinese: 看见
+    pinyin: kàn jiàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 飞翔
+    pinyin: fēi xiáng
+  - chinese: 的
+    pinyin: de
+  - chinese: 鹰
+    pinyin: yīng
+  - chinese: 。
+    pinyin: ''
+  english: She saw a flying eagle with binoculars.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 教室
+    pinyin: jiào shì
+  - chinese: 外面
+    pinyin: wài miàn
+  - chinese: 的
+    pinyin: de
+  - chinese: 窗户
+    pinyin: chuāng hu
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 贴
+    pinyin: tiē
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 通知
+    pinyin: tōng zhī
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 看见
+    pinyin: kàn jiàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: There is a notice posted on the window outside our classroom, did you see it?
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 叫
+    pinyin: jiào
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 开会
+    pinyin: kāi huì
+  - chinese: 。
+    pinyin: ''
+  english: They asked me to attend the meeting.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 叫
+    pinyin: jiào
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 们
+    pinyin: men
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: 。
+    pinyin: ''
+  english: She likes to invite her friends to eat together.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 叫
+    pinyin: jiào
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 三
+    pinyin: sān
+  - chinese: 次
+    pinyin: cì
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 不
+    pinyin: bù
+  - chinese: 回答
+    pinyin: huí dá
+  - chinese: ？
+    pinyin: ''
+  english: I called your name three times, why didn't you answer?
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 会
+    pinyin: huì
+  - chinese: 来
+    pinyin: lái
+  - chinese: 。
+    pinyin: ''
+  english: They will come tomorrow.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 去
+    pinyin: qù
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 来
+    pinyin: lái
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Let's go to your house.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 来
+    pinyin: lái
+  - chinese: 找
+    pinyin: zhǎo
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: He came to find me yesterday.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 来
+    pinyin: lái
+  - chinese: 中国
+    pinyin: Zhōng guó
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you want to come to China for a visit?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 回家
+    pinyin: huí jiā
+  - chinese: 。
+    pinyin: ''
+  english: He goes home every day.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 忘记
+    pinyin: wàng jì
+  - chinese: 了
+    pinyin: le
+  - chinese: 回答
+    pinyin: huí dá
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 。
+    pinyin: ''
+  english: He forgot to answer my question.
+
+- segments:
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 们
+    pinyin: men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 课堂
+    pinyin: kè táng
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 回答
+    pinyin: huí dá
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 。
+    pinyin: ''
+  english: The students answer questions in the classroom.
+
+- segments:
+  - chinese: 如果
+    pinyin: rú guǒ
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 赶
+    pinyin: gǎn
+  - chinese: 不
+    pinyin: bù
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 火车
+    pinyin: huǒ chē
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 回家
+    pinyin: huí jiā
+  - chinese: 。
+    pinyin: ''
+  english: If you can't catch the train, you can go back home.
+
+- segments:
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打算
+    pinyin: dǎ suàn
+  - chinese: 回
+    pinyin: huí
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 。
+    pinyin: ''
+  english: I plan to return to school tomorrow.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 会
+    pinyin: huì
+  - chinese: 在
+    pinyin: zài
+  - chinese: 下周
+    pinyin: xià zhōu
+  - chinese: 回来
+    pinyin: huí lai
+  - chinese: 。
+    pinyin: ''
+  english: He will come back next week.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 回家
+    pinyin: huí jiā
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 晚饭
+    pinyin: wǎn fàn
+  - chinese: 。
+    pinyin: ''
+  english: I go back home for dinner every day.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 回答
+    pinyin: huí dá
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 。
+    pinyin: ''
+  english: Please answer my question.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不想
+    pinyin: bù xiǎng
+  - chinese: 再
+    pinyin: zài
+  - chinese: 回忆
+    pinyin: huí yì
+  - chinese: 那
+    pinyin: nà
+  - chinese: 段
+    pinyin: duàn
+  - chinese: 往事
+    pinyin: wǎng shì
+  - chinese: 。
+    pinyin: ''
+  english: I don't want to recall that past anymore.
+
+- segments:
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 要
+    pinyin: yào
+  - chinese: 回到
+    pinyin: huí dào
+  - chinese: 原点
+    pinyin: yuán diǎn
+  - chinese: 重新
+    pinyin: chóng xīn
+  - chinese: 开始
+    pinyin: kāi shǐ
+  - chinese: 。
+    pinyin: ''
+  english: Tomorrow we need to go back to the starting point and start over.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 北京
+    pinyin: Běi jīng
+  - chinese: 。
+    pinyin: ''
+  english: I am going to Beijing tomorrow.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 去
+    pinyin: qù
+  - chinese: 超市
+    pinyin: chāo shì
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 菜
+    pinyin: cài
+  - chinese: ？
+    pinyin: ''
+  english: When are you going to the supermarket to buy groceries?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 去年
+    pinyin: qù nián
+  - chinese: 去
+    pinyin: qù
+  - chinese: 美国
+    pinyin: Měi guó
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: He traveled to the United States last year.
+
+- segments:
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 周末
+    pinyin: zhōu mò
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 。
+    pinyin: ''
+  english: Tomorrow is the weekend, we can go to the park to play.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 图书馆
+    pinyin: tú shū guǎn
+  - chinese: 借
+    pinyin: jiè
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I want to go to the library to borrow a book.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 了
+    pinyin: le
+  - chinese: 早饭
+    pinyin: zǎo fàn
+  - chinese: 。
+    pinyin: ''
+  english: I had breakfast today.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 水果
+    pinyin: shuǐ guǒ
+  - chinese: 。
+    pinyin: ''
+  english: He eats a lot of fruits every day.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 辣
+    pinyin: là
+  - chinese: 的
+    pinyin: de
+  - chinese: 食物
+    pinyin: shí wù
+  - chinese: 。
+    pinyin: ''
+  english: She likes to eat spicy food.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 紧张
+    pinyin: jǐn zhāng
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 不能
+    pinyin: bù néng
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 。
+    pinyin: ''
+  english: He can't eat when he is nervous.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 的
+    pinyin: de
+  - chinese: 饭菜
+    pinyin: fàn cài
+  - chinese: 。
+    pinyin: ''
+  english: I like to eat the dishes you make.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 。
+    pinyin: ''
+  english: I like to drink coffee.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 酒
+    pinyin: jiǔ
+  - chinese: 。
+    pinyin: ''
+  english: He drinks alcohol every day.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 。
+    pinyin: ''
+  english: She is drinking water.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 一
+    pinyin: yī
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can I have a glass of water?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 今晚
+    pinyin: jīn wǎn
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 累
+    pinyin: lèi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 早点
+    pinyin: zǎo diǎn
+  - chinese: 睡觉
+    pinyin: shuì jiào
+  - chinese: 。
+    pinyin: ''
+  english: I am very tired tonight, I want to go to bed early.
+
+- segments:
+  - chinese: 睡觉
+    pinyin: shuì jiào
+  - chinese: 前
+    pinyin: qián
+  - chinese: 不要
+    pinyin: bù yào
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 。
+    pinyin: ''
+  english: Don't drink coffee before going to bed.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 晚上
+    pinyin: wǎn shang
+  - chinese: 十
+    pinyin: shí
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 才
+    pinyin: cái
+  - chinese: 睡觉
+    pinyin: shuì jiào
+  - chinese: 。
+    pinyin: ''
+  english: He goes to bed at ten o'clock every night.
+
+- segments:
+  - chinese: 妹妹
+    pinyin: mèi mei
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 毛
+    pinyin: máo
+  - chinese: 绒
+    pinyin: róng
+  - chinese: 玩具
+    pinyin: wán jù
+  - chinese: 睡觉
+    pinyin: shuì jiào
+  - chinese: 。
+    pinyin: ''
+  english: My younger sister likes to sleep with stuffed toys.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 昨
+    pinyin: zuó
+  - chinese: 晚
+    pinyin: wǎn
+  - chinese: 睡
+    pinyin: shuì
+  - chinese: 了
+    pinyin: le
+  - chinese: 十
+    pinyin: shí
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: ，
+    pinyin: ''
+  - chinese: 睡
+    pinyin: shuì
+  - chinese: 得
+    pinyin: de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 舒服
+    pinyin: shū fu
+  - chinese: 。
+    pinyin: ''
+  english: I slept for ten hours last night and felt very comfortable.
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 打
+    pinyin: dǎ
+  - chinese: 电话
+    pinyin: diàn huà
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I called my mom yesterday.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 经常
+    pinyin: jīng cháng
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 打
+    pinyin: dǎ
+  - chinese: 电话
+    pinyin: diàn huà
+  - chinese: 。
+    pinyin: ''
+  english: I often call my friends.
+
+- segments:
+  - chinese: 妹妹
+    pinyin: mèi mei
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 打
+    pinyin: dǎ
+  - chinese: 电话
+    pinyin: diàn huà
+  - chinese: 。
+    pinyin: ''
+  english: My younger sister is making a phone call.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 打
+    pinyin: dǎ
+  - chinese: 电话
+    pinyin: diàn huà
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 医生
+    pinyin: yī shēng
+  - chinese: 预约
+    pinyin: yù yuē
+  - chinese: 。
+    pinyin: ''
+  english: I need to call the doctor to make an appointment.
+
+- segments:
+  - chinese: 老板
+    pinyin: lǎo bǎn
+  - chinese: 一直
+    pinyin: yī zhí
+  - chinese: 在
+    pinyin: zài
+  - chinese: 打
+    pinyin: dǎ
+  - chinese: 电话
+    pinyin: diàn huà
+  - chinese: 。
+    pinyin: ''
+  english: The boss has been on the phone all the time.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 早上
+    pinyin: zǎo shang
+  - chinese: 六
+    pinyin: liù
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 早饭
+    pinyin: zǎo fàn
+  - chinese: 。
+    pinyin: ''
+  english: He makes breakfast at 6 o'clock every morning.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 家务
+    pinyin: jiā wù
+  - chinese: 。
+    pinyin: ''
+  english: She enjoys doing housework.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 饭
+    pinyin: fàn
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Let's cook together.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 经常
+    pinyin: jīng cháng
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 运动
+    pinyin: yùn dòng
+  - chinese: 来
+    pinyin: lái
+  - chinese: 保持
+    pinyin: bǎo chí
+  - chinese: 健康
+    pinyin: jiàn kāng
+  - chinese: 。
+    pinyin: ''
+  english: He frequently exercises to stay healthy.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 决定
+    pinyin: jué dìng
+  - chinese: 要
+    pinyin: yào
+  - chinese: 自己
+    pinyin: zì jǐ
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 家具
+    pinyin: jiā jù
+  - chinese: 。
+    pinyin: ''
+  english: She decided to make a new piece of furniture by herself.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I need to buy a book.
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 。
+    pinyin: ''
+  english: Yesterday, I bought clothes at the store.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 经常
+    pinyin: jīng cháng
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 手机
+    pinyin: shǒu jī
+  - chinese: 。
+    pinyin: ''
+  english: He often buys new phones.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 一些
+    pinyin: yī xiē
+  - chinese: 水果
+    pinyin: shuǐ guǒ
+  - chinese: 。
+    pinyin: ''
+  english: I want to buy some fruits.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 超市
+    pinyin: chāo shì
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 食物
+    pinyin: shí wù
+  - chinese: 。
+    pinyin: ''
+  english: She is going to the supermarket to buy food.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 开车
+    pinyin: kāi chē
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 快
+    pinyin: kuài
+  - chinese: 。
+    pinyin: ''
+  english: He drives fast.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 不错
+    pinyin: bù cuò
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 去
+    pinyin: qù
+  - chinese: 开心
+    pinyin: kāi xīn
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: The weather is nice today, let's go have fun.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 开
+    pinyin: kāi
+  - chinese: 一
+    pinyin: yī
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 饭店
+    pinyin: fàn diàn
+  - chinese: 。
+    pinyin: ''
+  english: I want to open a restaurant.
+
+- segments:
+  - chinese: 开
+    pinyin: kāi
+  - chinese: 学
+    pinyin: xué
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 大家
+    pinyin: dà jiā
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 兴奋
+    pinyin: xīng fèn
+  - chinese: 。
+    pinyin: ''
+  english: School has started, everyone is excited.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 的
+    pinyin: de
+  - chinese: 长椅
+    pinyin: cháng yǐ
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 。
+    pinyin: ''
+  english: I am sitting on the bench in the park.
+
+- segments:
+  - chinese: 孩子们
+    pinyin: hái zi men
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 教室
+    pinyin: jiào shì
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 讲课
+    pinyin: jiǎng kè
+  - chinese: 。
+    pinyin: ''
+  english: The children are sitting in the classroom listening to the teacher's lecture.
+
+- segments:
+  - chinese: 爸爸
+    pinyin: bà ba
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 沙发
+    pinyin: shā fā
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电视
+    pinyin: diàn shì
+  - chinese: 。
+    pinyin: ''
+  english: Dad is sitting on the sofa watching TV.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 火车
+    pinyin: huǒ chē
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 。
+    pinyin: ''
+  english: He enjoys traveling by train.
+
+- segments:
+  - chinese: 老人
+    pinyin: lǎo rén
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 晒
+    pinyin: shài
+  - chinese: 太阳
+    pinyin: tài yang
+  - chinese: 。
+    pinyin: ''
+  english: The elderly person is sitting in the park sunbathing.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 椅子
+    pinyin: yǐ zi
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 。
+    pinyin: ''
+  english: He is sitting on the chair.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 窗户
+    pinyin: chuāng hu
+  - chinese: 旁边
+    pinyin: páng biān
+  - chinese: 看书
+    pinyin: kàn shū
+  - chinese: 。
+    pinyin: ''
+  english: She likes to sit by the window and read books.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 火车
+    pinyin: huǒ chē
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 。
+    pinyin: ''
+  english: I enjoy traveling by train.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: 。
+    pinyin: ''
+  english: We can sit together and have a meal.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 住
+    pinyin: zhù
+  - chinese: 在
+    pinyin: zài
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 房子
+    pinyin: fáng zi
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 。
+    pinyin: ''
+  english: We live in this house.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 住
+    pinyin: zhù
+  - chinese: 在
+    pinyin: zài
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 大
+    pinyin: dà
+  - chinese: 城市
+    pinyin: chéng shì
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 。
+    pinyin: ''
+  english: She lives in a big city.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 爸爸
+    pinyin: bà ba
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 住
+    pinyin: zhù
+  - chinese: 在
+    pinyin: zài
+  - chinese: 农村
+    pinyin: nóng cūn
+  - chinese: 。
+    pinyin: ''
+  english: My parents live in the countryside.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 住
+    pinyin: zhù
+  - chinese: 得
+    pinyin: dé
+  - chinese: 远离
+    pinyin: yuǎn lí
+  - chinese: 市
+    pinyin: shì
+  - chinese: 中心
+    pinyin: zhōng xīn
+  - chinese: 。
+    pinyin: ''
+  english: We live far away from the city center.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 住
+    pinyin: zhù
+  - chinese: 在
+    pinyin: zài
+  - chinese: 同
+    pinyin: tóng
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小区
+    pinyin: xiǎo qū
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 。
+    pinyin: ''
+  english: They live in the same residential area.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 晚上
+    pinyin: wǎn shang
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 。
+    pinyin: ''
+  english: I study every night.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 的
+    pinyin: de
+  - chinese: 知识
+    pinyin: zhī shi
+  - chinese: 。
+    pinyin: ''
+  english: I enjoy learning new knowledge.
+
+- segments:
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 种
+    pinyin: zhǒng
+  - chinese: 持续
+    pinyin: chí xù
+  - chinese: 的
+    pinyin: de
+  - chinese: 过程
+    pinyin: guò chéng
+  - chinese: 。
+    pinyin: ''
+  english: Learning is a continuous process.
+
+- segments:
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 使
+    pinyin: shǐ
+  - chinese: 人
+    pinyin: rén
+  - chinese: 进步
+    pinyin: jìn bù
+  - chinese: 。
+    pinyin: ''
+  english: Learning makes people progress.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 图书馆
+    pinyin: tú shū guǎn
+  - chinese: 认真
+    pinyin: rèn zhēn
+  - chinese: 地
+    pinyin: de
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 。
+    pinyin: ''
+  english: She studies diligently at the library.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 早上
+    pinyin: zǎo shang
+  - chinese: 八
+    pinyin: bā
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 开始
+    pinyin: kāi shǐ
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 。
+    pinyin: ''
+  english: I start working at eight o'clock in the morning every day.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 努力
+    pinyin: nǔ lì
+  - chinese: ，
+    pinyin: ''
+  - chinese: 从
+    pinyin: cóng
+  - chinese: 不
+    pinyin: bù
+  - chinese: 拖延
+    pinyin: tuō yán
+  - chinese: 。
+    pinyin: ''
+  english: She works hard and never procrastinates.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 满意
+    pinyin: mǎn yì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 成果
+    pinyin: chéng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: I am satisfied with the results of my work.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 一
+    pinyin: yī
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 公司
+    pinyin: gōng sī
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 了
+    pinyin: le
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 年
+    pinyin: nián
+  - chinese: 。
+    pinyin: ''
+  english: I have been working at a company for five years.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 对
+    pinyin: duì
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 充满
+    pinyin: chōng mǎn
+  - chinese: 热情
+    pinyin: rè qíng
+  - chinese: 和
+    pinyin: hé
+  - chinese: 动力
+    pinyin: dòng lì
+  - chinese: 。
+    pinyin: ''
+  english: He is enthusiastic and motivated about his work.
+
+- segments:
+  - chinese: 外面
+    pinyin: wài miàn
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: 。
+    pinyin: ''
+  english: It is raining outside.
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 下
+    pinyin: xià
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 场
+    pinyin: chǎng
+  - chinese: 大雨
+    pinyin: dà yǔ
+  - chinese: 。
+    pinyin: ''
+  english: There was a heavy rain yesterday.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 希望
+    pinyin: xī wàng
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 不
+    pinyin: bù
+  - chinese: 会
+    pinyin: huì
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: 。
+    pinyin: ''
+  english: I hope it won't rain tomorrow.
+
+- segments:
+  - chinese: 刚刚
+    pinyin: gāng gang
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 现在
+    pinyin: xiàn zài
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 凉爽
+    pinyin: liáng shuǎng
+  - chinese: 。
+    pinyin: ''
+  english: It just rained, and now the weather is cool.
+
+- segments:
+  - chinese: 好久
+    pinyin: hǎo jiǔ
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 土地
+    pinyin: tǔ dì
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 干裂
+    pinyin: gān liè
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: It hasn't rained for a long time, and the land has cracked.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 爱
+    pinyin: ài
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 。
+    pinyin: ''
+  english: I love you.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 爱
+    pinyin: ài
+  - chinese: 读书
+    pinyin: dú shū
+  - chinese: 。
+    pinyin: ''
+  english: She loves reading.
+
+- segments:
+  - chinese: 孩子们
+    pinyin: hái zi men
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 爱
+    pinyin: ài
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 。
+    pinyin: ''
+  english: The children all love playing.
+
+- segments:
+  - chinese: 爷爷
+    pinyin: yé ye
+  - chinese: 爱
+    pinyin: ài
+  - chinese: 唱歌
+    pinyin: chàng gē
+  - chinese: 。
+    pinyin: ''
+  english: Grandpa loves singing.
+
+- segments:
+  - chinese: 狗狗
+    pinyin: gǒu gōu
+  - chinese: 总
+    pinyin: zǒng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 爱
+    pinyin: ài
+  - chinese: 追
+    pinyin: zhuī
+  - chinese: 球
+    pinyin: qiú
+  - chinese: 。
+    pinyin: ''
+  english: The dog always loves chasing the ball.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: 。
+    pinyin: ''
+  english: I want to eat.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 哪儿
+    pinyin: nǎ r
+  - chinese: ？
+    pinyin: ''
+  english: Where do you want to go?
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 学
+    pinyin: xué
+  - chinese: 中文
+    pinyin: Zhōng wén
+  - chinese: 。
+    pinyin: ''
+  english: They want to learn Chinese.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: I want to watch a movie.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 和
+    pinyin: hé
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 聊天
+    pinyin: liáo tiān
+  - chinese: 。
+    pinyin: ''
+  english: She wants to chat with you.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 认识
+    pinyin: rèn shi
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: We met at school.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 年
+    pinyin: nián
+  - chinese: 前
+    pinyin: qián
+  - chinese: 认识
+    pinyin: rèn shi
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: We met two years ago.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 是
+    pinyin: shì
+  - chinese: 通过
+    pinyin: tōng guò
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 认识
+    pinyin: rèn shi
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: We met through a friend.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 中
+    pinyin: zhōng
+  - chinese: 认识
+    pinyin: rèn shi
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: We met while traveling.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 是
+    pinyin: shì
+  - chinese: 在
+    pinyin: zài
+  - chinese: 社交
+    pinyin: shè jiāo
+  - chinese: 活动
+    pinyin: huó dòng
+  - chinese: 中
+    pinyin: zhōng
+  - chinese: 认识
+    pinyin: rèn shi
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: We met at a social event.
+
+- segments:
+  - chinese: 星期六
+    pinyin: Xīng qī liù
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 去
+    pinyin: qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: I will go watch a movie on Saturday.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 饭
+    pinyin: fàn
+  - chinese: 。
+    pinyin: ''
+  english: I can cook.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 会
+    pinyin: huì
+  - chinese: 游泳
+    pinyin: yóu yǒng
+  - chinese: 。
+    pinyin: ''
+  english: He knows how to swim.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 中文
+    pinyin: Zhōng wén
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you speak Chinese?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 孩子
+    pinyin: hái zi
+  - chinese: 会
+    pinyin: huì
+  - chinese: 弹
+    pinyin: tán
+  - chinese: 钢琴
+    pinyin: gāng qín
+  - chinese: 。
+    pinyin: ''
+  english: My child can play the piano.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 用
+    pinyin: yòng
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 钥匙
+    pinyin: yào shi
+  - chinese: 开门
+    pinyin: kāi mén
+  - chinese: 。
+    pinyin: ''
+  english: I can use this key to open the door.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一下
+    pinyin: yī xià
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you help me for a moment?
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 能
+    pinyin: néng
+  - chinese: 唱
+    pinyin: chàng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 种
+    pinyin: zhǒng
+  - chinese: 歌
+    pinyin: gē
+  - chinese: 。
+    pinyin: ''
+  english: She can sing many different songs.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 能
+    pinyin: néng
+  - chinese: 学
+    pinyin: xué
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 词
+    pinyin: cí
+  - chinese: 。
+    pinyin: ''
+  english: We can learn many new words every day.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 能
+    pinyin: néng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: 内
+    pinyin: nèi
+  - chinese: 完成
+    pinyin: wán chéng
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 。
+    pinyin: ''
+  english: He can finish the work within an hour.
+
+- segments:
+  - chinese: 对不起
+    pinyin: duì bu qǐ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 迟到
+    pinyin: chí dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I'm sorry, I am late.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 了
+    pinyin: le
+  - chinese: 声
+    pinyin: shēng
+  - chinese: “
+    pinyin: ''
+  - chinese: 对不起
+    pinyin: duì bu qǐ
+  - chinese: ”
+    pinyin: ''
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: He said "sorry" and then left.
+
+- segments:
+  - chinese: 当
+    pinyin: dāng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 犯错
+    pinyin: fàn cuò
+  - chinese: 时
+    pinyin: shí
+  - chinese: ，
+    pinyin: ''
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 对不起
+    pinyin: duì bu qǐ
+  - chinese: 。
+    pinyin: ''
+  english: You should say sorry when you make a mistake.
+
+- segments:
+  - chinese: 对不起
+    pinyin: duì bu qǐ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打翻
+    pinyin: dǎ fān
+  - chinese: 了
+    pinyin: le
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 。
+    pinyin: ''
+  english: Sorry, I knocked over your water glass.
+
+- segments:
+  - chinese: 小朋友
+    pinyin: xiǎo péng yǒu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 撞
+    pinyin: zhuàng
+  - chinese: 到
+    pinyin: dào
+  - chinese: 别人
+    pinyin: bié ren
+  - chinese: 了
+    pinyin: le
+  - chinese: 要
+    pinyin: yào
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 对不起
+    pinyin: duì bu qǐ
+  - chinese: 。
+    pinyin: ''
+  english: Children, you should say sorry when you bump into someone.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 弄
+    pinyin: nòng
+  - chinese: 丢
+    pinyin: diū
+  - chinese: 了
+    pinyin: le
+  - chinese: 那
+    pinyin: nà
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: ，
+    pinyin: ''
+  - chinese: 但是
+    pinyin: dàn shì
+  - chinese: 没关系
+    pinyin: méi guān xi
+  - chinese: 。
+    pinyin: ''
+  english: I lost that book, but it doesn't matter.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 忘记
+    pinyin: wàng jì
+  - chinese: 带
+    pinyin: dài
+  - chinese: 钥匙
+    pinyin: yào shi
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 没关系
+    pinyin: méi guān xi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 备用
+    pinyin: bèi yòng
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: He forgot to bring his keys, no worries, I have a spare set.
+
+- segments:
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 预报
+    pinyin: yù bào
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 会
+    pinyin: huì
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 没关系
+    pinyin: méi guān xi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 改
+    pinyin: gǎi
+  - chinese: 天
+    pinyin: tiān
+  - chinese: 再
+    pinyin: zài
+  - chinese: 去
+    pinyin: qù
+  - chinese: 野餐
+    pinyin: yě cān
+  - chinese: 。
+    pinyin: ''
+  english: The weather forecast says it will rain today, no problem, we can go for a picnic another day.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 笔
+    pinyin: bǐ
+  - chinese: 弄
+    pinyin: nòng
+  - chinese: 坏
+    pinyin: huài
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 没关系
+    pinyin: méi guān xi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 还有
+    pinyin: hái yǒu
+  - chinese: 别的
+    pinyin: bié de
+  - chinese: 。
+    pinyin: ''
+  english: You broke my pen, it's all right, I have others.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 了
+    pinyin: le
+  - chinese: 大
+    pinyin: dà
+  - chinese: 忙
+    pinyin: máng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不客气
+    pinyin: bù kè qi
+  - chinese: 是
+    pinyin: shì
+  - chinese: 不
+    pinyin: bù
+  - chinese: 行
+    pinyin: xíng
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: You've been a big help; it would be wrong not to say thank you.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 了
+    pinyin: le
+  - chinese: 声
+    pinyin: shēng
+  - chinese: “
+    pinyin: ''
+  - chinese: 谢谢
+    pinyin: xiè xie
+  - chinese: ”，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 回答
+    pinyin: huí dá
+  - chinese: “
+    pinyin: ''
+  - chinese: 不客气
+    pinyin: bù kè qi
+  - chinese: ”。
+    pinyin: ''
+  english: He said "thank you," and I replied, "you're welcome."
+
+- segments:
+  - chinese: 别
+    pinyin: bié
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 不客气
+    pinyin: bù kè qi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: Don't mention it, it's the least I could do.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 拿
+    pinyin: ná
+  - chinese: 行李
+    pinyin: xíng li
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 对
+    pinyin: duì
+  - chinese: 她
+    pinyin: tā
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 不客气
+    pinyin: bù kè qi
+  - chinese: 。
+    pinyin: ''
+  english: She helped me with my luggage, and I told her "no need to be polite."
+
+- segments:
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 让座
+    pinyin: ràng zuò
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 不
+    pinyin: bù
+  - chinese: 要
+    pinyin: yào
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 不客气
+    pinyin: bù kè qi
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: If I give you my seat, there's no need to say "don't be polite."
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 。
+    pinyin: ''
+  english: This apple tastes good.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 人
+    pinyin: rén
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: My friend is a good person.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 的
+    pinyin: de
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: Today's weather is good.
+
+- segments:
+  - chinese: 爸爸
+    pinyin: bà ba
+  - chinese: 的
+    pinyin: de
+  - chinese: 厨艺
+    pinyin: chú yì
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: Dad's cooking skills are good.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 的
+    pinyin: de
+  - chinese: 礼物
+    pinyin: lǐ wù
+  - chinese: 。
+    pinyin: ''
+  english: This book is a very good gift.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 大
+    pinyin: dà
+  - chinese: 。
+    pinyin: ''
+  english: This room is big.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 大
+    pinyin: dà
+  - chinese: 家庭
+    pinyin: jiā tíng
+  - chinese: 。
+    pinyin: ''
+  english: He has a big family.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一块
+    pinyin: yī kuài
+  - chinese: 大
+    pinyin: dà
+  - chinese: 饼
+    pinyin: bǐng
+  - chinese: 。
+    pinyin: ''
+  english: This is a big pancake.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 辆
+    pinyin: liàng
+  - chinese: 大巴
+    pinyin: dà bā
+  - chinese: 。
+    pinyin: ''
+  english: I bought a big bus.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 只是
+    pinyin: zhǐ shì
+  - chinese: 个
+    pinyin: gè
+  - chinese: 大
+    pinyin: dà
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 。
+    pinyin: ''
+  english: This is just a big problem.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小
+    pinyin: xiǎo
+  - chinese: 孩子
+    pinyin: hái zi
+  - chinese: 。
+    pinyin: ''
+  english: This is a little child.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 小狗
+    pinyin: xiǎo gǒu
+  - chinese: 。
+    pinyin: ''
+  english: I like small dogs.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小
+    pinyin: xiǎo
+  - chinese: 姐姐
+    pinyin: jiě jie
+  - chinese: 。
+    pinyin: ''
+  english: He has a younger sister.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小
+    pinyin: xiǎo
+  - chinese: 店
+    pinyin: diàn
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 便宜
+    pinyin: pián yi
+  - chinese: 。
+    pinyin: ''
+  english: This small shop is very cheap.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 读
+    pinyin: dú
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 小说
+    pinyin: xiǎo shuō
+  - chinese: 。
+    pinyin: ''
+  english: I am reading a novel.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 了
+    pinyin: le
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 水果
+    pinyin: shuǐ guǒ
+  - chinese: 。
+    pinyin: ''
+  english: I ate a lot of fruits.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 多少
+    pinyin: duō shao
+  - chinese: 页
+    pinyin: yè
+  - chinese: ？
+    pinyin: ''
+  english: How many pages does this book have?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 多
+    pinyin: duō
+  - chinese: 高
+    pinyin: gāo
+  - chinese: ？
+    pinyin: ''
+  english: How tall is he?
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 晚上
+    pinyin: wǎn shang
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 多
+    pinyin: duō
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: ？
+    pinyin: ''
+  english: How cold is it tonight?
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 下
+    pinyin: xià
+  - chinese: 了
+    pinyin: le
+  - chinese: 多
+    pinyin: duō
+  - chinese: 长
+    pinyin: cháng
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 的
+    pinyin: de
+  - chinese: 雨
+    pinyin: yǔ
+  - chinese: ？
+    pinyin: ''
+  english: How long did it rain yesterday?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 多少
+    pinyin: duō shǎo
+  - chinese: 钱
+    pinyin: qián
+  - chinese: ？
+    pinyin: ''
+  english: How much does this book cost?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 告诉
+    pinyin: gào sù
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 城市
+    pinyin: chéng shì
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 多少
+    pinyin: duō shǎo
+  - chinese: 人口
+    pinyin: rén kǒu
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you tell me how many people live in this city?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 汉字
+    pinyin: hàn zì
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 读
+    pinyin: dú
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 告诉
+    pinyin: gào sù
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: I don't know how to pronounce this Chinese character, can you tell me?
+
+- segments:
+  - chinese: 请问
+    pinyin: qǐng wèn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 酒店
+    pinyin: jiǔ diàn
+  - chinese: 的
+    pinyin: de
+  - chinese: 客房
+    pinyin: kè fáng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 多少
+    pinyin: duō shǎo
+  - chinese: 间
+    pinyin: jiān
+  - chinese: ？
+    pinyin: ''
+  english: Excuse me, how many rooms does this hotel have?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 少
+    pinyin: shǎo
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 集
+    pinyin: jí
+  - chinese: 电视剧
+    pinyin: diàn shì jù
+  - chinese: 。
+    pinyin: ''
+  english: I missed one episode of the TV series.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 的
+    pinyin: de
+  - chinese: 味道
+    pinyin: wèi dao
+  - chinese: 有点儿
+    pinyin: yǒu diǎn r
+  - chinese: 少
+    pinyin: shǎo
+  - chinese: 。
+    pinyin: ''
+  english: This dish lacks a bit of flavor.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 回答
+    pinyin: huí dá
+  - chinese: 太
+    pinyin: tài
+  - chinese: 短
+    pinyin: duǎn
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: His answer was too brief.
+
+- segments:
+  - chinese: 在
+    pinyin: zài
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 城市
+    pinyin: chéng shì
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 看到
+    pinyin: kàn dào
+  - chinese: 野生
+    pinyin: yě shēng
+  - chinese: 动物
+    pinyin: dòng wù
+  - chinese: 的
+    pinyin: de
+  - chinese: 机会
+    pinyin: jī huì
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 少
+    pinyin: shǎo
+  - chinese: 。
+    pinyin: ''
+  english: In this city, there are few opportunities to see wild animals.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 。
+    pinyin: ''
+  english: Today is cold.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 手
+    pinyin: shǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 。
+    pinyin: ''
+  english: My hands are cold.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 。
+    pinyin: ''
+  english: This room is cold.
+
+- segments:
+  - chinese: 冬天
+    pinyin: dōng tiān
+  - chinese: 的
+    pinyin: de
+  - chinese: 风
+    pinyin: fēng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 。
+    pinyin: ''
+  english: The wind in winter is cold.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 感觉
+    pinyin: gǎn jué
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 。
+    pinyin: ''
+  english: I feel cold.
+
+- segments:
+  - chinese: 外面
+    pinyin: wài miàn
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 热
+    pinyin: rè
+  - chinese: 。
+    pinyin: ''
+  english: It is hot outside.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 热
+    pinyin: rè
+  - chinese: 茶
+    pinyin: chá
+  - chinese: 。
+    pinyin: ''
+  english: I like to drink hot tea.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 觉得
+    pinyin: jué de
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 热
+    pinyin: rè
+  - chinese: 。
+    pinyin: ''
+  english: She thinks the room is hot.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 热
+    pinyin: rè
+  - chinese: 。
+    pinyin: ''
+  english: Today's weather is hot.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 汤
+    pinyin: tāng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 热
+    pinyin: rè
+  - chinese: 。
+    pinyin: ''
+  english: This soup is hot.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 高兴
+    pinyin: gāo xìng
+  - chinese: 见到
+    pinyin: jiàn dào
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 。
+    pinyin: ''
+  english: I am very happy to meet you.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 听到
+    pinyin: tīng dào
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 消息
+    pinyin: xiāo xi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 高兴
+    pinyin: gāo xìng
+  - chinese: 。
+    pinyin: ''
+  english: She is happy to hear good news.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 笑容
+    pinyin: xiào róng
+  - chinese: 让
+    pinyin: ràng
+  - chinese: 人
+    pinyin: rén
+  - chinese: 感到
+    pinyin: gǎn dào
+  - chinese: 高兴
+    pinyin: gāo xìng
+  - chinese: 。
+    pinyin: ''
+  english: His smile makes people feel happy.
+
+- segments:
+  - chinese: 大家
+    pinyin: dà jiā
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 对
+    pinyin: duì
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 成功
+    pinyin: chéng gōng
+  - chinese: 感到
+    pinyin: gǎn dào
+  - chinese: 高兴
+    pinyin: gāo xìng
+  - chinese: 。
+    pinyin: ''
+  english: Everyone is happy for his success.
+
+- segments:
+  - chinese: 小
+    pinyin: xiǎo
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 看到
+    pinyin: kàn dào
+  - chinese: 食物
+    pinyin: shí wù
+  - chinese: 非常
+    pinyin: fēi cháng
+  - chinese: 高兴
+    pinyin: gāo xìng
+  - chinese: 。
+    pinyin: ''
+  english: The kitten is very happy to see food.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 穿
+    pinyin: chuān
+  - chinese: 的
+    pinyin: de
+  - chinese: 裙子
+    pinyin: qún zi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 。
+    pinyin: ''
+  english: She is wearing a beautiful dress.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 幅
+    pinyin: fú
+  - chinese: 画
+    pinyin: huà
+  - chinese: 非常
+    pinyin: fēi cháng
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 。
+    pinyin: ''
+  english: This painting is very beautiful.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一头
+    pinyin: yī tóu
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 的
+    pinyin: de
+  - chinese: 长发
+    pinyin: cháng fà
+  - chinese: 。
+    pinyin: ''
+  english: She has beautiful long hair.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 花园
+    pinyin: huā yuán
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 种
+    pinyin: zhǒng
+  - chinese: 满
+    pinyin: mǎn
+  - chinese: 了
+    pinyin: le
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 的
+    pinyin: de
+  - chinese: 花
+    pinyin: huā
+  - chinese: 。
+    pinyin: ''
+  english: This garden is filled with beautiful flowers.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 笑容
+    pinyin: xiào róng
+  - chinese: 非常
+    pinyin: fēi cháng
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 。
+    pinyin: ''
+  english: Her smile is very beautiful.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 不
+    pinyin: bù
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: ？
+    pinyin: ''
+  english: Why aren't you eating?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 迟到
+    pinyin: chí dào
+  - chinese: 了
+    pinyin: le
+  - chinese: ？
+    pinyin: ''
+  english: Why is he late?
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 要
+    pinyin: yào
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 汉语
+    pinyin: Hàn yǔ
+  - chinese: ？
+    pinyin: ''
+  english: Why do we need to learn Chinese?
+
+- segments:
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 这么
+    pinyin: zhè me
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: ？
+    pinyin: ''
+  english: Why is it so cold?
+
+- segments:
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 这么
+    pinyin: zhè me
+  - chinese: 有趣
+    pinyin: yǒu qù
+  - chinese: ？
+    pinyin: ''
+  english: Why is this book so interesting?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 三
+    pinyin: sān
+  - chinese: 个
+    pinyin: gè
+  - chinese: 手机
+    pinyin: shǒu jī
+  - chinese: 。
+    pinyin: ''
+  english: I have three mobile phones.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 三
+    pinyin: sān
+  - chinese: 百
+    pinyin: bǎi
+  - chinese: 页
+    pinyin: yè
+  - chinese: 。
+    pinyin: ''
+  english: This book has three hundred pages.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 三
+    pinyin: sān
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 三
+    pinyin: sān
+  - chinese: 号
+    pinyin: hào
+  - chinese: 。
+    pinyin: ''
+  english: Today is the third of March.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 箱子
+    pinyin: xiāng zi
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 三
+    pinyin: sān
+  - chinese: 层
+    pinyin: céng
+  - chinese: 。
+    pinyin: ''
+  english: This box has three layers.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 三
+    pinyin: sān
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 。
+    pinyin: ''
+  english: I drink three cups of coffee every day.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 三
+    pinyin: sān
+  - chinese: 个
+    pinyin: gè
+  - chinese: 弟弟
+    pinyin: dì di
+  - chinese: 。
+    pinyin: ''
+  english: He has three younger brothers.
+
+- segments:
+  - chinese: 三
+    pinyin: sān
+  - chinese: 岁
+    pinyin: suì
+  - chinese: 的
+    pinyin: de
+  - chinese: 孩子
+    pinyin: hái zi
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 幼儿园
+    pinyin: yòu ér yuán
+  - chinese: 。
+    pinyin: ''
+  english: A three-year-old child can go to kindergarten.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 是
+    pinyin: shì
+  - chinese: 三
+    pinyin: sān
+  - chinese: 姐妹
+    pinyin: jiě mèi
+  - chinese: 中
+    pinyin: zhōng
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 小
+    pinyin: xiǎo
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: I am the youngest of three sisters.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 要
+    pinyin: yào
+  - chinese: 练习
+    pinyin: liàn xí
+  - chinese: 三
+    pinyin: sān
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: 的
+    pinyin: de
+  - chinese: 钢琴
+    pinyin: gāng qín
+  - chinese: 。
+    pinyin: ''
+  english: I practice the piano for three hours every day.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 花
+    pinyin: huā
+  - chinese: 了
+    pinyin: le
+  - chinese: 三
+    pinyin: sān
+  - chinese: 分钟
+    pinyin: fēn zhōng
+  - chinese: 解决
+    pinyin: jiě jué
+  - chinese: 了
+    pinyin: le
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 。
+    pinyin: ''
+  english: He solved this problem in three minutes.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 四
+    pinyin: sì
+  - chinese: 百
+    pinyin: bǎi
+  - chinese: 页
+    pinyin: yè
+  - chinese: 。
+    pinyin: ''
+  english: This book has four hundred pages.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 辆
+    pinyin: liàng
+  - chinese: 汽车
+    pinyin: qì chē
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 四
+    pinyin: sì
+  - chinese: 个
+    pinyin: gè
+  - chinese: 轮子
+    pinyin: lún zi
+  - chinese: 。
+    pinyin: ''
+  english: This car has four wheels.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 四
+    pinyin: sì
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 。
+    pinyin: ''
+  english: Please give me four pieces of clothing.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 四
+    pinyin: sì
+  - chinese: 个
+    pinyin: gè
+  - chinese: 周末
+    pinyin: zhōu mò
+  - chinese: 。
+    pinyin: ''
+  english: This month has four weekends.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 四
+    pinyin: sì
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 四
+    pinyin: sì
+  - chinese: 号
+    pinyin: hào
+  - chinese: 。
+    pinyin: ''
+  english: Today is the fourth of April.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 四
+    pinyin: sì
+  - chinese: 口
+    pinyin: kǒu
+  - chinese: 人
+    pinyin: rén
+  - chinese: 。
+    pinyin: ''
+  english: There are four people in my family.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 份
+    pinyin: fèn
+  - chinese: 文件
+    pinyin: wén jiàn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 四
+    pinyin: sì
+  - chinese: 个
+    pinyin: gè
+  - chinese: 部分
+    pinyin: bù fen
+  - chinese: 。
+    pinyin: ''
+  english: This document has four sections.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 套
+    pinyin: tào
+  - chinese: 家具
+    pinyin: jiā jù
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 四
+    pinyin: sì
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 椅子
+    pinyin: yǐ zi
+  - chinese: 。
+    pinyin: ''
+  english: This set of furniture has four chairs.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 箱子
+    pinyin: xiāng zi
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 四
+    pinyin: sì
+  - chinese: 个
+    pinyin: gè
+  - chinese: 拉链
+    pinyin: lā liàn
+  - chinese: 。
+    pinyin: ''
+  english: This suitcase has four zippers.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 辆
+    pinyin: liàng
+  - chinese: 自行车
+    pinyin: zì xíng chē
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 四
+    pinyin: sì
+  - chinese: 个
+    pinyin: gè
+  - chinese: 刹车
+    pinyin: shā chē
+  - chinese: 。
+    pinyin: ''
+  english: This bicycle has four brakes.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 个
+    pinyin: gè
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: I have five apples.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 生日
+    pinyin: shēng rì
+  - chinese: 是
+    pinyin: shì
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 日
+    pinyin: rì
+  - chinese: 。
+    pinyin: ''
+  english: Her birthday is on May 5th.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: These are five books.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 睡
+    pinyin: shuì
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: 。
+    pinyin: ''
+  english: I sleep for five hours every day.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 箱子
+    pinyin: xiāng zi
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 。
+    pinyin: ''
+  english: There are five cats in this box.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 条
+    pinyin: tiáo
+  - chinese: 裤子
+    pinyin: kù zi
+  - chinese: 。
+    pinyin: ''
+  english: These are five pairs of pants.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 岁
+    pinyin: suì
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: She is five years old.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 经常
+    pinyin: jīng cháng
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: 。
+    pinyin: ''
+  english: I often study for five hours.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每
+    pinyin: měi
+  - chinese: 周
+    pinyin: zhōu
+  - chinese: 打
+    pinyin: dǎ
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 次
+    pinyin: cì
+  - chinese: 篮球
+    pinyin: lán qiú
+  - chinese: 。
+    pinyin: ''
+  english: I play basketball five times a week.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 个
+    pinyin: gè
+  - chinese: 人
+    pinyin: rén
+  - chinese: 。
+    pinyin: ''
+  english: There are five people in this room.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 六
+    pinyin: liù
+  - chinese: 个
+    pinyin: gè
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: I have six apples.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 班
+    pinyin: bān
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 六十
+    pinyin: liù shí
+  - chinese: 个
+    pinyin: gè
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 。
+    pinyin: ''
+  english: There are sixty students in our class.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 收到
+    pinyin: shōu dào
+  - chinese: 六
+    pinyin: liù
+  - chinese: 封
+    pinyin: fēng
+  - chinese: 电子
+    pinyin: diàn zǐ
+  - chinese: 邮件
+    pinyin: yóu jiàn
+  - chinese: 。
+    pinyin: ''
+  english: I received six emails.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 课本
+    pinyin: kè běn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 六
+    pinyin: liù
+  - chinese: 页
+    pinyin: yè
+  - chinese: 。
+    pinyin: ''
+  english: This textbook has six pages.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 六
+    pinyin: liù
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 。
+    pinyin: ''
+  english: I drink six cups of water every day.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 六
+    pinyin: liù
+  - chinese: 盏
+    pinyin: zhǎn
+  - chinese: 灯
+    pinyin: dēng
+  - chinese: 。
+    pinyin: ''
+  english: There are six lights in my room.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 睡
+    pinyin: shuì
+  - chinese: 六
+    pinyin: liù
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: 。
+    pinyin: ''
+  english: I sleep for six hours every day.
+
+- segments:
+  - chinese: 星期六
+    pinyin: Xīng qī liù
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: I'm going to watch a movie on Saturday.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 七
+    pinyin: qī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: I bought seven apples today.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 七
+    pinyin: qī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I have seven books.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 电话
+    pinyin: diàn huà
+  - chinese: 号码
+    pinyin: hào mǎ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 七
+    pinyin: qī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 数字
+    pinyin: shù zì
+  - chinese: 。
+    pinyin: ''
+  english: My phone number has seven digits.
+
+- segments:
+  - chinese: 世界
+    pinyin: shì jiè
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 七
+    pinyin: qī
+  - chinese: 大
+    pinyin: dà
+  - chinese: 洲
+    pinyin: zhōu
+  - chinese: 。
+    pinyin: ''
+  english: There are seven continents in the world.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 年轻人
+    pinyin: nián qīng rén
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 七
+    pinyin: qī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 兄弟
+    pinyin: xiōng dì
+  - chinese: 姐妹
+    pinyin: jiě mèi
+  - chinese: 。
+    pinyin: ''
+  english: That young man has seven siblings.
+
+- segments:
+  - chinese: 星期天
+    pinyin: Xīng qī tiān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 每
+    pinyin: měi
+  - chinese: 周
+    pinyin: zhōu
+  - chinese: 的
+    pinyin: de
+  - chinese: 第
+    pinyin: dì
+  - chinese: 七
+    pinyin: qī
+  - chinese: 天
+    pinyin: tiān
+  - chinese: 。
+    pinyin: ''
+  english: Sunday is the seventh day of each week.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 的
+    pinyin: de
+  - chinese: 第
+    pinyin: dì
+  - chinese: 七
+    pinyin: qī
+  - chinese: 天
+    pinyin: tiān
+  - chinese: 要
+    pinyin: yào
+  - chinese: 举行
+    pinyin: jǔ xíng
+  - chinese: 聚会
+    pinyin: jù huì
+  - chinese: 。
+    pinyin: ''
+  english: We will hold a party on the seventh day of this month.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 星座
+    pinyin: xīng zuò
+  - chinese: 代表
+    pinyin: dài biǎo
+  - chinese: 七
+    pinyin: qī
+  - chinese: 月份
+    pinyin: yuè fèn
+  - chinese: 的
+    pinyin: de
+  - chinese: 出生
+    pinyin: chū shēng
+  - chinese: 人
+    pinyin: rén
+  - chinese: 。
+    pinyin: ''
+  english: This constellation represents people born in July.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 家里
+    pinyin: jiā lǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 八
+    pinyin: bā
+  - chinese: 个
+    pinyin: gè
+  - chinese: 人
+    pinyin: rén
+  - chinese: 。
+    pinyin: ''
+  english: There are eight people in his family.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 八十
+    pinyin: bā shí
+  - chinese: 页
+    pinyin: yè
+  - chinese: 。
+    pinyin: ''
+  english: That book has eighty pages.
+
+- segments:
+  - chinese: 八
+    pinyin: bā
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 夏天
+    pinyin: xià tiān
+  - chinese: 的
+    pinyin: de
+  - chinese: 最后
+    pinyin: zuì hòu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 。
+    pinyin: ''
+  english: August is the last month of summer.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 星期
+    pinyin: xīng qī
+  - chinese: 的
+    pinyin: de
+  - chinese: 星期日
+    pinyin: Xīng qī rì
+  - chinese: 是
+    pinyin: shì
+  - chinese: 八
+    pinyin: bā
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 号
+    pinyin: hào
+  - chinese: 。
+    pinyin: ''
+  english: The Sunday of this week is August 9th.
+
+- segments:
+  - chinese: 八
+    pinyin: bā
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 整
+    pinyin: zhěng
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 开始
+    pinyin: kāi shǐ
+  - chinese: 开会
+    pinyin: kāi huì
+  - chinese: 。
+    pinyin: ''
+  english: We start the meeting at eight sharp.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 八
+    pinyin: bā
+  - chinese: 号
+    pinyin: hào
+  - chinese: 生日
+    pinyin: shēng rì
+  - chinese: 。
+    pinyin: ''
+  english: My birthday is on the eighth of this month.
+
+- segments:
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 八
+    pinyin: bā
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 四
+    pinyin: sì
+  - chinese: 号
+    pinyin: hào
+  - chinese: 。
+    pinyin: ''
+  english: Tomorrow is August 4th.
+
+- segments:
+  - chinese: 刚
+    pinyin: gāng
+  - chinese: 收到
+    pinyin: shōu dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 八
+    pinyin: bā
+  - chinese: 封
+    pinyin: fēng
+  - chinese: 电子
+    pinyin: diàn zǐ
+  - chinese: 邮件
+    pinyin: yóu jiàn
+  - chinese: 。
+    pinyin: ''
+  english: Just received eight emails.
+
+- segments:
+  - chinese: 八十
+    pinyin: bā shí
+  - chinese: 加
+    pinyin: jiā
+  - chinese: 十
+    pinyin: shí
+  - chinese: 等于
+    pinyin: děng yú
+  - chinese: 九十
+    pinyin: jiǔ shí
+  - chinese: 。
+    pinyin: ''
+  english: Eighty plus ten equals ninety.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 页
+    pinyin: yè
+  - chinese: 。
+    pinyin: ''
+  english: This book has nine pages.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 铅笔
+    pinyin: qiān bǐ
+  - chinese: 。
+    pinyin: ''
+  english: I have nine pencils.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 个
+    pinyin: gè
+  - chinese: 椅子
+    pinyin: yǐ zi
+  - chinese: 。
+    pinyin: ''
+  english: This room has nine chairs.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 块
+    pinyin: kuài
+  - chinese: 钱
+    pinyin: qián
+  - chinese: 。
+    pinyin: ''
+  english: I need nine yuan.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 一共
+    pinyin: yī gòng
+  - chinese: 写
+    pinyin: xiě
+  - chinese: 了
+    pinyin: le
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 条
+    pinyin: tiáo
+  - chinese: 规则
+    pinyin: guī zé
+  - chinese: 。
+    pinyin: ''
+  english: They wrote a total of nine rules.
+
+- segments:
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 生日
+    pinyin: shēng rì
+  - chinese: 。
+    pinyin: ''
+  english: September is my birthday month.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 钟
+    pinyin: zhōng
+  - chinese: 起床
+    pinyin: qǐ chuáng
+  - chinese: 。
+    pinyin: ''
+  english: I wake up at nine o'clock.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 已经
+    pinyin: yǐ jīng
+  - chinese: 打
+    pinyin: dǎ
+  - chinese: 了
+    pinyin: le
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 个
+    pinyin: gè
+  - chinese: 电话
+    pinyin: diàn huà
+  - chinese: ，
+    pinyin: ''
+  - chinese: 还是
+    pinyin: hái shi
+  - chinese: 没
+    pinyin: méi
+  - chinese: 人
+    pinyin: rén
+  - chinese: 接
+    pinyin: jiē
+  - chinese: 。
+    pinyin: ''
+  english: I have already made nine calls, but no one answered.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 餐厅
+    pinyin: cān tīng
+  - chinese: 十
+    pinyin: shí
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 关门
+    pinyin: guān mén
+  - chinese: 。
+    pinyin: ''
+  english: This restaurant closes at 10 o'clock.
+
+- segments:
+  - chinese: 十
+    pinyin: shí
+  - chinese: 个
+    pinyin: gè
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 教室
+    pinyin: jiào shì
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 。
+    pinyin: ''
+  english: Ten students are studying in the classroom.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 十
+    pinyin: shí
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 十
+    pinyin: shí
+  - chinese: 号
+    pinyin: hào
+  - chinese: 。
+    pinyin: ''
+  english: Today is the 10th of October.
+
+- segments:
+  - chinese: 公交车
+    pinyin: gōng jiāo chē
+  - chinese: 每
+    pinyin: měi
+  - chinese: 十
+    pinyin: shí
+  - chinese: 分钟
+    pinyin: fēn zhōng
+  - chinese: 来
+    pinyin: lái
+  - chinese: 一
+    pinyin: yī
+  - chinese: 班
+    pinyin: bān
+  - chinese: 。
+    pinyin: ''
+  english: The bus comes every 10 minutes.
+
+- segments:
+  - chinese: 爸爸
+    pinyin: bà ba
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 了
+    pinyin: le
+  - chinese: 十
+    pinyin: shí
+  - chinese: 个
+    pinyin: gè
+  - chinese: 蛋糕
+    pinyin: dàn gāo
+  - chinese: 。
+    pinyin: ''
+  english: Dad made ten cakes.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 菜谱
+    pinyin: cài pǔ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 十
+    pinyin: shí
+  - chinese: 道
+    pinyin: dào
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 。
+    pinyin: ''
+  english: This recipe has ten dishes.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 旅行团
+    pinyin: lǚ xíng tuán
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 十
+    pinyin: shí
+  - chinese: 个
+    pinyin: gè
+  - chinese: 人
+    pinyin: rén
+  - chinese: 。
+    pinyin: ''
+  english: That travel group has ten people.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 十
+    pinyin: shí
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 来
+    pinyin: lái
+  - chinese: 供应
+    pinyin: gōng yìng
+  - chinese: 图书馆
+    pinyin: tú shū guǎn
+  - chinese: 。
+    pinyin: ''
+  english: We need ten books to supply the library.
+
+- segments:
+  - chinese: 小狗
+    pinyin: xiǎo gǒu
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 十
+    pinyin: shí
+  - chinese: 个
+    pinyin: gè
+  - chinese: 兄弟
+    pinyin: xiōng dì
+  - chinese: 姐妹
+    pinyin: jiě mèi
+  - chinese: 。
+    pinyin: ''
+  english: The puppy has ten siblings.
+
+- segments:
+  - chinese: 今晚
+    pinyin: jīn wǎn
+  - chinese: 十
+    pinyin: shí
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 重要
+    pinyin: zhòng yào
+  - chinese: 会议
+    pinyin: huì yì
+  - chinese: 。
+    pinyin: ''
+  english: There is an important meeting at 10 o'clock tonight.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 十一
+    pinyin: shí yī
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 十一
+    pinyin: shí yī
+  - chinese: 号
+    pinyin: hào
+  - chinese: 。
+    pinyin: ''
+  english: Today is November 11th.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 生日
+    pinyin: shēng rì
+  - chinese: 是
+    pinyin: shì
+  - chinese: 十一
+    pinyin: shí yī
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 十一
+    pinyin: shí yī
+  - chinese: 号
+    pinyin: hào
+  - chinese: 。
+    pinyin: ''
+  english: My birthday is on November 11th.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 住
+    pinyin: zhù
+  - chinese: 在
+    pinyin: zài
+  - chinese: 十一
+    pinyin: shí yī
+  - chinese: 巷
+    pinyin: xiàng
+  - chinese: 。
+    pinyin: ''
+  english: My house is located in alley number 11.
+
+- segments:
+  - chinese: 在
+    pinyin: zài
+  - chinese: 十一
+    pinyin: shí yī
+  - chinese: 路
+    pinyin: lù
+  - chinese: 拐角
+    pinyin: guǎi jiǎo
+  - chinese: 处
+    pinyin: chù
+  - chinese: ，
+    pinyin: ''
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一家
+    pinyin: yī jiā
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 店
+    pinyin: diàn
+  - chinese: 。
+    pinyin: ''
+  english: There is a coffee shop at the corner of 11th street.
+
+- segments:
+  - chinese: 街
+    pinyin: jiē
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 十一
+    pinyin: shí yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 灯柱
+    pinyin: dēng zhù
+  - chinese: 。
+    pinyin: ''
+  english: There are eleven lamp posts on the street.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 月底
+    pinyin: yuè dǐ
+  - chinese: 是
+    pinyin: shì
+  - chinese: 十一
+    pinyin: shí yī
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 二十
+    pinyin: èr shí
+  - chinese: 号
+    pinyin: hào
+  - chinese: 。
+    pinyin: ''
+  english: The end of this month is November 20th.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 十一
+    pinyin: shí yī
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 睡觉
+    pinyin: shuì jiào
+  - chinese: 。
+    pinyin: ''
+  english: I go to bed at 11 o'clock every day.
+
+- segments:
+  - chinese: 餐厅
+    pinyin: cān tīng
+  - chinese: 十一
+    pinyin: shí yī
+  - chinese: 号
+    pinyin: hào
+  - chinese: 桌
+    pinyin: zhuō
+  - chinese: 有人
+    pinyin: yǒu rén
+  - chinese: 预订
+    pinyin: yù dìng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: Table number 11 in the restaurant has been reserved.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 十一
+    pinyin: shí yī
+  - chinese: 岁
+    pinyin: suì
+  - chinese: 时
+    pinyin: shí
+  - chinese: 的
+    pinyin: de
+  - chinese: 照片
+    pinyin: zhào piàn
+  - chinese: 。
+    pinyin: ''
+  english: This is a photo of me when I was eleven years old.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 十二
+    pinyin: shí èr
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I have twelve books.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 十二
+    pinyin: shí èr
+  - chinese: 个
+    pinyin: gè
+  - chinese: 星期
+    pinyin: xīng qī
+  - chinese: 。
+    pinyin: ''
+  english: This month has twelve weeks.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 生日
+    pinyin: shēng rì
+  - chinese: 是
+    pinyin: shì
+  - chinese: 十二
+    pinyin: shí èr
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 二十
+    pinyin: èr shí
+  - chinese: 日
+    pinyin: rì
+  - chinese: 。
+    pinyin: ''
+  english: Her birthday is on December 20th.
+
+- segments:
+  - chinese: 公司
+    pinyin: gōng sī
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 十二
+    pinyin: shí èr
+  - chinese: 位
+    pinyin: wèi
+  - chinese: 员工
+    pinyin: yuán gōng
+  - chinese: 。
+    pinyin: ''
+  english: The company has twelve employees.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 是
+    pinyin: shì
+  - chinese: 十二
+    pinyin: shí èr
+  - chinese: 年
+    pinyin: nián
+  - chinese: 的
+    pinyin: de
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: They have been good friends for twelve years.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 母亲
+    pinyin: mǔ qīn
+  - chinese: 的
+    pinyin: de
+  - chinese: 生日
+    pinyin: shēng rì
+  - chinese: 是
+    pinyin: shì
+  - chinese: 火星
+    pinyin: huǒ xīng
+  - chinese: 的
+    pinyin: de
+  - chinese: 十二
+    pinyin: shí èr
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 。
+    pinyin: ''
+  english: My mother's birthday is in December on Mars.
+
+- segments:
+  - chinese: 已经
+    pinyin: yǐ jīng
+  - chinese: 过去
+    pinyin: guò qù
+  - chinese: 了
+    pinyin: le
+  - chinese: 十二
+    pinyin: shí èr
+  - chinese: 分钟
+    pinyin: fēn zhōng
+  - chinese: 。
+    pinyin: ''
+  english: Twelve minutes have already passed.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 十二
+    pinyin: shí èr
+  - chinese: 个
+    pinyin: gè
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: I bought twelve apples.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: Please give me two apples.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 。
+    pinyin: ''
+  english: I have two cats.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 会议
+    pinyin: huì yì
+  - chinese: 。
+    pinyin: ''
+  english: There are two meetings today.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 披萨
+    pinyin: pī sà
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 种
+    pinyin: zhǒng
+  - chinese: 口味
+    pinyin: kǒu wèi
+  - chinese: 。
+    pinyin: ''
+  english: This pizza has two flavors.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I want to buy two books.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 。
+    pinyin: ''
+  english: Please give me two cups of water.
+
+- segments:
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 考试
+    pinyin: kǎo shì
+  - chinese: 。
+    pinyin: ''
+  english: There are two exams tomorrow.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 包
+    pinyin: bāo
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 种
+    pinyin: zhǒng
+  - chinese: 颜色
+    pinyin: yán sè
+  - chinese: 的
+    pinyin: de
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 。
+    pinyin: ''
+  english: There are two colors of clothes in this bag.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 。
+    pinyin: ''
+  english: I drink two cups of coffee every day.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 分店
+    pinyin: fēn diàn
+  - chinese: 。
+    pinyin: ''
+  english: This shop has two branches.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 爱好
+    pinyin: ài hào
+  - chinese: 是
+    pinyin: shì
+  - chinese: 打
+    pinyin: dǎ
+  - chinese: 篮球
+    pinyin: lán qiú
+  - chinese: 。
+    pinyin: ''
+  english: My hobby is playing basketball.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 爱好
+    pinyin: ài hào
+  - chinese: 是
+    pinyin: shì
+  - chinese: 旅游
+    pinyin: lǚ yóu
+  - chinese: 。
+    pinyin: ''
+  english: My hobby is traveling.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 爱好
+    pinyin: ài hào
+  - chinese: 是
+    pinyin: shì
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: My hobby is watching movies.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 爱好
+    pinyin: ài hào
+  - chinese: 是
+    pinyin: shì
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 音乐
+    pinyin: yīn yuè
+  - chinese: 。
+    pinyin: ''
+  english: My hobby is listening to music.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 爱好
+    pinyin: ài hào
+  - chinese: 是
+    pinyin: shì
+  - chinese: 阅读
+    pinyin: yuè dú
+  - chinese: 。
+    pinyin: ''
+  english: My hobby is reading.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 爱好
+    pinyin: ài hào
+  - chinese: 是
+    pinyin: shì
+  - chinese: 写作
+    pinyin: xiě zuò
+  - chinese: 。
+    pinyin: ''
+  english: My hobby is writing.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 爱好
+    pinyin: ài hào
+  - chinese: 是
+    pinyin: shì
+  - chinese: 烹饪
+    pinyin: pēng rèn
+  - chinese: 。
+    pinyin: ''
+  english: My hobby is cooking.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 爱好
+    pinyin: ài hào
+  - chinese: 是
+    pinyin: shì
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What are your hobbies?
+
+- segments:
+  - chinese: 白天
+    pinyin: bái tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 睡觉
+    pinyin: shuì jiào
+  - chinese: 。
+    pinyin: ''
+  english: I like to sleep during the day.
+
+- segments:
+  - chinese: 白天
+    pinyin: bái tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: I like to watch movies during the day.
+
+- segments:
+  - chinese: 白天
+    pinyin: bái tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 音乐
+    pinyin: yīn yuè
+  - chinese: 。
+    pinyin: ''
+  english: I like to listen to music during the day.
+
+- segments:
+  - chinese: 白天
+    pinyin: bái tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 游戏
+    pinyin: yóu xì
+  - chinese: 。
+    pinyin: ''
+  english: I like to play games during the day.
+
+- segments:
+  - chinese: 白天
+    pinyin: bái tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I like to read books during the day.
+
+- segments:
+  - chinese: 白天
+    pinyin: bái tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 散步
+    pinyin: sàn bù
+  - chinese: 。
+    pinyin: ''
+  english: I like to take a walk during the day.
+
+- segments:
+  - chinese: 白天
+    pinyin: bái tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 。
+    pinyin: ''
+  english: I like to drink coffee during the day.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 只
+    pinyin: zhǐ
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 了
+    pinyin: le
+  - chinese: 半天
+    pinyin: bàn tiān
+  - chinese: 。
+    pinyin: ''
+  english: I only worked half a day today.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 只
+    pinyin: zhǐ
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 了
+    pinyin: le
+  - chinese: 半天
+    pinyin: bàn tiān
+  - chinese: 。
+    pinyin: ''
+  english: I only studied for half a day today.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 感谢
+    pinyin: gǎn xiè
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 帮忙
+    pinyin: bāng máng
+  - chinese: 。
+    pinyin: ''
+  english: I am very grateful for your help.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 帮忙
+    pinyin: bāng máng
+  - chinese: 。
+    pinyin: ''
+  english: I need your help.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 帮忙
+    pinyin: bāng máng
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can I help?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 帮忙
+    pinyin: bāng máng
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you help?
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 帮忙
+    pinyin: bāng máng
+  - chinese: 。
+    pinyin: ''
+  english: We need help.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 高兴
+    pinyin: gāo xìng
+  - chinese: 能
+    pinyin: néng
+  - chinese: 帮忙
+    pinyin: bāng máng
+  - chinese: 。
+    pinyin: ''
+  english: I am very happy to help.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 帮忙
+    pinyin: bāng máng
+  - chinese: 。
+    pinyin: ''
+  english: I don't need help.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 本子
+    pinyin: běn zi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 。
+    pinyin: ''
+  english: This notebook is very beautiful.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 本子
+    pinyin: běn zi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 便宜
+    pinyin: pián yi
+  - chinese: 。
+    pinyin: ''
+  english: This notebook is very cheap.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 本子
+    pinyin: běn zi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 贵
+    pinyin: guì
+  - chinese: 。
+    pinyin: ''
+  english: This notebook is very expensive.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 本子
+    pinyin: běn zi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 大
+    pinyin: dà
+  - chinese: 。
+    pinyin: ''
+  english: This notebook is very big.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 本子
+    pinyin: běn zi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 小
+    pinyin: xiǎo
+  - chinese: 。
+    pinyin: ''
+  english: This notebook is very small.
+
+- segments:
+  - chinese: 北边
+    pinyin: běi biān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 大
+    pinyin: dà
+  - chinese: 城市
+    pinyin: chéng shì
+  - chinese: 。
+    pinyin: ''
+  english: There is a big city in the north.
+
+- segments:
+  - chinese: 北边
+    pinyin: běi biān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 大
+    pinyin: dà
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 。
+    pinyin: ''
+  english: There is a big park in the north.
+
+- segments:
+  - chinese: 北边
+    pinyin: běi biān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 大
+    pinyin: dà
+  - chinese: 湖
+    pinyin: hú
+  - chinese: 。
+    pinyin: ''
+  english: There is a big lake in the north.
+
+- segments:
+  - chinese: 北边
+    pinyin: běi biān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 大
+    pinyin: dà
+  - chinese: 山
+    pinyin: shān
+  - chinese: 。
+    pinyin: ''
+  english: There is a big mountain in the north.
+
+- segments:
+  - chinese: 北边
+    pinyin: běi biān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 大
+    pinyin: dà
+  - chinese: 河
+    pinyin: hé
+  - chinese: 。
+    pinyin: ''
+  english: There is a big river in the north.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 包子
+    pinyin: bāo zi
+  - chinese: 。
+    pinyin: ''
+  english: I want to eat buns.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 包子
+    pinyin: bāo zi
+  - chinese: 。
+    pinyin: ''
+  english: I like to eat buns.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 包子
+    pinyin: bāo zi
+  - chinese: 。
+    pinyin: ''
+  english: I don't like to eat buns.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 包子
+    pinyin: bāo zi
+  - chinese: 。
+    pinyin: ''
+  english: I don't want to eat buns.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 这里
+    pinyin: zhè lǐ
+  - chinese: 住
+    pinyin: zhù
+  - chinese: 了
+    pinyin: le
+  - chinese: 半年
+    pinyin: bàn nián
+  - chinese: 。
+    pinyin: ''
+  english: I have lived here for half a year.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 这里
+    pinyin: zhè lǐ
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 了
+    pinyin: le
+  - chinese: 半年
+    pinyin: bàn nián
+  - chinese: 。
+    pinyin: ''
+  english: I have worked here for half a year.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 这里
+    pinyin: zhè lǐ
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 了
+    pinyin: le
+  - chinese: 半年
+    pinyin: bàn nián
+  - chinese: 。
+    pinyin: ''
+  english: I have studied here for half a year.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 这里
+    pinyin: zhè lǐ
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 了
+    pinyin: le
+  - chinese: 半年
+    pinyin: bàn nián
+  - chinese: 。
+    pinyin: ''
+  english: I have played here for half a year.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 这里
+    pinyin: zhè lǐ
+  - chinese: 旅游
+    pinyin: lǚ yóu
+  - chinese: 了
+    pinyin: le
+  - chinese: 半年
+    pinyin: bàn nián
+  - chinese: 。
+    pinyin: ''
+  english: I have traveled here for half a year.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 半
+    pinyin: bàn
+  - chinese: 个
+    pinyin: gè
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: I want to eat half an apple.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 半
+    pinyin: bàn
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 。
+    pinyin: ''
+  english: I want to drink half a cup of water.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 半
+    pinyin: bàn
+  - chinese: 粒
+    pinyin: lì
+  - chinese: 鸡蛋
+    pinyin: jī dàn
+  - chinese: 。
+    pinyin: ''
+  english: I want to eat half an egg.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 半
+    pinyin: bàn
+  - chinese: 个
+    pinyin: gè
+  - chinese: 西瓜
+    pinyin: xī guā
+  - chinese: 。
+    pinyin: ''
+  english: I want to eat half a watermelon.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 半
+    pinyin: bàn
+  - chinese: 个
+    pinyin: gè
+  - chinese: 香蕉
+    pinyin: xiāng jiāo
+  - chinese: 。
+    pinyin: ''
+  english: I want to eat half a banana.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 常常
+    pinyin: cháng cháng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 图书馆
+    pinyin: tú shū guǎn
+  - chinese: 。
+    pinyin: ''
+  english: I often go to the library.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 常常
+    pinyin: cháng cháng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 超市
+    pinyin: chāo shì
+  - chinese: 。
+    pinyin: ''
+  english: I often go to the supermarket.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 常常
+    pinyin: cháng cháng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 。
+    pinyin: ''
+  english: I often go to the park.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 常常
+    pinyin: cháng cháng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 博物馆
+    pinyin: bó wù guǎn
+  - chinese: 。
+    pinyin: ''
+  english: I often go to the museum.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 常常
+    pinyin: cháng cháng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 电影院
+    pinyin: diàn yǐng yuàn
+  - chinese: 。
+    pinyin: ''
+  english: I often go to the cinema.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 英语
+    pinyin: Yīng yǔ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 差
+    pinyin: chà
+  - chinese: 。
+    pinyin: ''
+  english: My English is very poor.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 数学
+    pinyin: shù xué
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 差
+    pinyin: chà
+  - chinese: 。
+    pinyin: ''
+  english: My math is very poor.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 物理
+    pinyin: wù lǐ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 差
+    pinyin: chà
+  - chinese: 。
+    pinyin: ''
+  english: My physics is very poor.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 化学
+    pinyin: huà xué
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 差
+    pinyin: chà
+  - chinese: 。
+    pinyin: ''
+  english: My chemistry is very poor.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 生物
+    pinyin: shēng wù
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 差
+    pinyin: chà
+  - chinese: 。
+    pinyin: ''
+  english: My biology is very poor.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 出来
+    pinyin: chū lái
+  - chinese: 玩儿
+    pinyin: wán r
+  - chinese: 。
+    pinyin: ''
+  english: I came out to play.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 出来
+    pinyin: chū lái
+  - chinese: 旅游
+    pinyin: lǚ yóu
+  - chinese: 。
+    pinyin: ''
+  english: I came out to travel.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 出来
+    pinyin: chū lái
+  - chinese: 散
+    pinyin: sàn
+  - chinese: 步
+    pinyin: bù
+  - chinese: 。
+    pinyin: ''
+  english: I came out to take a walk.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 出来
+    pinyin: chū lái
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 。
+    pinyin: ''
+  english: I came out to buy vegetables.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 出来
+    pinyin: chū lái
+  - chinese: 购物
+    pinyin: gòu wù
+  - chinese: 。
+    pinyin: ''
+  english: I came out to go shopping.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 晴朗
+    pinyin: qíng lǎng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 天空
+    pinyin: tiān kōng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 白
+    pinyin: bái
+  - chinese: 。
+    pinyin: ''
+  english: Today the weather is clear, and the sky is very bright.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 白
+    pinyin: bái
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 白
+    pinyin: bái
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 。
+    pinyin: ''
+  english: I eat and drink for free.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 白
+    pinyin: bái
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 了
+    pinyin: le
+  - chinese: 他
+    pinyin: tā
+  - chinese: 一
+    pinyin: yī
+  - chinese: 千
+    pinyin: qiān
+  - chinese: 块
+    pinyin: kuài
+  - chinese: 钱
+    pinyin: qián
+  - chinese: 。
+    pinyin: ''
+  english: I gave him a thousand yuan for free.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 白
+    pinyin: bái
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 了
+    pinyin: le
+  - chinese: 他
+    pinyin: tā
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I gave him a book for free.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 白
+    pinyin: bái
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 了
+    pinyin: le
+  - chinese: 他
+    pinyin: tā
+  - chinese: 一
+    pinyin: yī
+  - chinese: 顿
+    pinyin: dùn
+  - chinese: 饭
+    pinyin: fàn
+  - chinese: 。
+    pinyin: ''
+  english: I gave him a meal for free.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 白
+    pinyin: bái
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 了
+    pinyin: le
+  - chinese: 他
+    pinyin: tā
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 票
+    pinyin: piào
+  - chinese: 。
+    pinyin: ''
+  english: I gave him a movie ticket for free.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 白
+    pinyin: bái
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 了
+    pinyin: le
+  - chinese: 他
+    pinyin: tā
+  - chinese: 一
+    pinyin: yī
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 。
+    pinyin: ''
+  english: I gave him a cup of coffee for free.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 白
+    pinyin: bái
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 了
+    pinyin: le
+  - chinese: 他
+    pinyin: tā
+  - chinese: 一
+    pinyin: yī
+  - chinese: 盒
+    pinyin: hé
+  - chinese: 巧克力
+    pinyin: qiǎo kè lì
+  - chinese: 。
+    pinyin: ''
+  english: I gave him a box of chocolates for free.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 北
+    pinyin: běi
+  - chinese: 印度
+    pinyin: Yìn dù
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 。
+    pinyin: ''
+  english: We are going to travel to North India.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不用
+    pinyin: bù yòng
+  - chinese: 担心
+    pinyin: dān xīn
+  - chinese: 。
+    pinyin: ''
+  english: You don't have to worry.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不用
+    pinyin: bù yòng
+  - chinese: 害怕
+    pinyin: hài pà
+  - chinese: 。
+    pinyin: ''
+  english: You don't have to be afraid.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不用
+    pinyin: bù yòng
+  - chinese: 着急
+    pinyin: zháo jí
+  - chinese: 。
+    pinyin: ''
+  english: You don't have to be in a hurry.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不用
+    pinyin: bù yòng
+  - chinese: 等
+    pinyin: děng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 。
+    pinyin: ''
+  english: You don't have to wait for me.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不用
+    pinyin: bù yòng
+  - chinese: 谢
+    pinyin: xiè
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 。
+    pinyin: ''
+  english: You don't have to thank me.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不用
+    pinyin: bù yòng
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 东西
+    pinyin: dōng xī
+  - chinese: 。
+    pinyin: ''
+  english: You don't have to buy anything.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不用
+    pinyin: bù yòng
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 饭
+    pinyin: fàn
+  - chinese: 。
+    pinyin: ''
+  english: You don't have to cook.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不用
+    pinyin: bù yòng
+  - chinese: 打扫
+    pinyin: dǎ sǎo
+  - chinese: 卫生
+    pinyin: wèi shēng
+  - chinese: 。
+    pinyin: ''
+  english: You don't have to clean.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不用
+    pinyin: bù yòng
+  - chinese: 洗
+    pinyin: xǐ
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 。
+    pinyin: ''
+  english: You don't have to do laundry.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不用
+    pinyin: bù yòng
+  - chinese: 洗
+    pinyin: xǐ
+  - chinese: 碗
+    pinyin: wǎn
+  - chinese: 。
+    pinyin: ''
+  english: You don't have to wash the dishes.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不用
+    pinyin: bù yòng
+  - chinese: 刷
+    pinyin: shuā
+  - chinese: 牙
+    pinyin: yá
+  - chinese: 。
+    pinyin: ''
+  english: You don't have to brush your teeth.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不用
+    pinyin: bù yòng
+  - chinese: 剪
+    pinyin: jiǎn
+  - chinese: 指甲
+    pinyin: zhǐ jia
+  - chinese: 。
+    pinyin: ''
+  english: You don't have to cut your nails.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不用
+    pinyin: bù yòng
+  - chinese: 化妆
+    pinyin: huà zhuāng
+  - chinese: 。
+    pinyin: ''
+  english: You don't have to put on makeup.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不用
+    pinyin: bù yòng
+  - chinese: 穿
+    pinyin: chuān
+  - chinese: 鞋
+    pinyin: xié
+  - chinese: 。
+    pinyin: ''
+  english: You don't have to wear shoes.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 车票
+    pinyin: chē piào
+  - chinese: 。
+    pinyin: ''
+  english: I bought a ticket.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 火车票
+    pinyin: huǒ chē piào
+  - chinese: 。
+    pinyin: ''
+  english: I bought a train ticket.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 飞机票
+    pinyin: fēi jī piào
+  - chinese: 。
+    pinyin: ''
+  english: I bought a plane ticket.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 公交车
+    pinyin: gōng jiāo chē
+  - chinese: 票
+    pinyin: piào
+  - chinese: 。
+    pinyin: ''
+  english: I bought a bus ticket.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 地铁
+    pinyin: dì tiě
+  - chinese: 票
+    pinyin: piào
+  - chinese: 。
+    pinyin: ''
+  english: I bought a subway ticket.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 出去
+    pinyin: chū qù
+  - chinese: 玩儿
+    pinyin: wán r
+  - chinese: 。
+    pinyin: ''
+  english: I went out to play.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 出去
+    pinyin: chū qù
+  - chinese: 旅游
+    pinyin: lǚ yóu
+  - chinese: 。
+    pinyin: ''
+  english: I went out to travel.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 出去
+    pinyin: chū qù
+  - chinese: 散
+    pinyin: sàn
+  - chinese: 步
+    pinyin: bù
+  - chinese: 。
+    pinyin: ''
+  english: I went out to take a walk.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 出去
+    pinyin: chū qù
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 。
+    pinyin: ''
+  english: I went out to buy vegetables.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 出去
+    pinyin: chū qù
+  - chinese: 购物
+    pinyin: gòu wù
+  - chinese: 。
+    pinyin: ''
+  english: I went out to go shopping.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 出去
+    pinyin: chū qù
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 饭
+    pinyin: fàn
+  - chinese: 。
+    pinyin: ''
+  english: I went out to eat.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 出去
+    pinyin: chū qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: I went out to watch a movie.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 出去
+    pinyin: chū qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 演出
+    pinyin: yǎn chū
+  - chinese: 。
+    pinyin: ''
+  english: I went out to see a performance.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 出去
+    pinyin: chū qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 展览
+    pinyin: zhǎn lǎn
+  - chinese: 。
+    pinyin: ''
+  english: I went out to see an exhibition.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 出去
+    pinyin: chū qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 比赛
+    pinyin: bǐ sài
+  - chinese: 。
+    pinyin: ''
+  english: I went out to watch a game.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打车
+    pinyin: dǎ chē
+  - chinese: 去
+    pinyin: qù
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 。
+    pinyin: ''
+  english: I took a taxi to school.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打车
+    pinyin: dǎ chē
+  - chinese: 去
+    pinyin: qù
+  - chinese: 公司
+    pinyin: gōng sī
+  - chinese: 。
+    pinyin: ''
+  english: I took a taxi to the company.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打车
+    pinyin: dǎ chē
+  - chinese: 去
+    pinyin: qù
+  - chinese: 机场
+    pinyin: jī chǎng
+  - chinese: 。
+    pinyin: ''
+  english: I took a taxi to the airport.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打车
+    pinyin: dǎ chē
+  - chinese: 去
+    pinyin: qù
+  - chinese: 火车站
+    pinyin: huǒ chē zhàn
+  - chinese: 。
+    pinyin: ''
+  english: I took a taxi to the train station.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打车
+    pinyin: dǎ chē
+  - chinese: 去
+    pinyin: qù
+  - chinese: 公交车
+    pinyin: gōng jiāo chē
+  - chinese: 站
+    pinyin: zhàn
+  - chinese: 。
+    pinyin: ''
+  english: I took a taxi to the bus station.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打车
+    pinyin: dǎ chē
+  - chinese: 去
+    pinyin: qù
+  - chinese: 地铁站
+    pinyin: dì tiě zhàn
+  - chinese: 。
+    pinyin: ''
+  english: I took a taxi to the subway station.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打车
+    pinyin: dǎ chē
+  - chinese: 去
+    pinyin: qù
+  - chinese: 银行
+    pinyin: yín háng
+  - chinese: 。
+    pinyin: ''
+  english: I took a taxi to the bank.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打车
+    pinyin: dǎ chē
+  - chinese: 去
+    pinyin: qù
+  - chinese: 医院
+    pinyin: yī yuàn
+  - chinese: 。
+    pinyin: ''
+  english: I took a taxi to the hospital.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打车
+    pinyin: dǎ chē
+  - chinese: 去
+    pinyin: qù
+  - chinese: 超市
+    pinyin: chāo shì
+  - chinese: 。
+    pinyin: ''
+  english: I took a taxi to the supermarket.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打车
+    pinyin: dǎ chē
+  - chinese: 去
+    pinyin: qù
+  - chinese: 商场
+    pinyin: shāng chǎng
+  - chinese: 。
+    pinyin: ''
+  english: I took a taxi to the mall.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打电话
+    pinyin: dǎ diàn huà
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 他
+    pinyin: tā
+  - chinese: 。
+    pinyin: ''
+  english: I called him.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打电话
+    pinyin: dǎ diàn huà
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 她
+    pinyin: tā
+  - chinese: 。
+    pinyin: ''
+  english: I called her.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打电话
+    pinyin: dǎ diàn huà
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 爸爸
+    pinyin: bà ba
+  - chinese: 。
+    pinyin: ''
+  english: I called my father.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打电话
+    pinyin: dǎ diàn huà
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 。
+    pinyin: ''
+  english: I called my mother.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打电话
+    pinyin: dǎ diàn huà
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 哥哥
+    pinyin: gē ge
+  - chinese: 。
+    pinyin: ''
+  english: I called my brother.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打电话
+    pinyin: dǎ diàn huà
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 姐姐
+    pinyin: jiě jie
+  - chinese: 。
+    pinyin: ''
+  english: I called my sister.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 打电话
+    pinyin: dǎ diàn huà
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 。
+    pinyin: ''
+  english: I will call you tomorrow.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 下
+    pinyin: xià
+  - chinese: 周
+    pinyin: zhōu
+  - chinese: 打电话
+    pinyin: dǎ diàn huà
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 。
+    pinyin: ''
+  english: I will call you next week.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 大学
+    pinyin: dà xué
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 。
+    pinyin: ''
+  english: I study at the university.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 大学
+    pinyin: dà xué
+  - chinese: 上课
+    pinyin: shàng kè
+  - chinese: 。
+    pinyin: ''
+  english: I take classes at the university.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 大学
+    pinyin: dà xué
+  - chinese: 参加
+    pinyin: cān jiā
+  - chinese: 活动
+    pinyin: huó dòng
+  - chinese: 。
+    pinyin: ''
+  english: I participate in activities at the university.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 大学
+    pinyin: dà xué
+  - chinese: 参加
+    pinyin: cān jiā
+  - chinese: 社团
+    pinyin: shè tuán
+  - chinese: 。
+    pinyin: ''
+  english: I participate in clubs at the university.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 大学
+    pinyin: dà xué
+  - chinese: 参加
+    pinyin: cān jiā
+  - chinese: 比赛
+    pinyin: bǐ sài
+  - chinese: 。
+    pinyin: ''
+  english: I participate in competitions at the university.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 大学
+    pinyin: dà xué
+  - chinese: 参加
+    pinyin: cān jiā
+  - chinese: 演出
+    pinyin: yǎn chū
+  - chinese: 。
+    pinyin: ''
+  english: I participate in performances at the university.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 大学
+    pinyin: dà xué
+  - chinese: 参加
+    pinyin: cān jiā
+  - chinese: 展览
+    pinyin: zhǎn lǎn
+  - chinese: 。
+    pinyin: ''
+  english: I participate in exhibitions at the university.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 大学
+    pinyin: dà xué
+  - chinese: 参加
+    pinyin: cān jiā
+  - chinese: 讲座
+    pinyin: jiǎng zuò
+  - chinese: 。
+    pinyin: ''
+  english: I participate in lectures at the university.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 大学
+    pinyin: dà xué
+  - chinese: 参加
+    pinyin: cān jiā
+  - chinese: 研讨会
+    pinyin: yán tǎo huì
+  - chinese: 。
+    pinyin: ''
+  english: I participate in seminars at the university.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 大学生
+    pinyin: dà xué shēng
+  - chinese: 。
+    pinyin: ''
+  english: I am a college student.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 刚
+    pinyin: gāng
+  - chinese: 毕业
+    pinyin: bì yè
+  - chinese: 的
+    pinyin: de
+  - chinese: 大学生
+    pinyin: dà xué shēng
+  - chinese: 。
+    pinyin: ''
+  english: I am a recent college graduate.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 在
+    pinyin: zài
+  - chinese: 校
+    pinyin: xiào
+  - chinese: 大学生
+    pinyin: dà xué shēng
+  - chinese: 。
+    pinyin: ''
+  english: I am a current college student.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 毕业
+    pinyin: bì yè
+  - chinese: 大学生
+    pinyin: dà xué shēng
+  - chinese: 。
+    pinyin: ''
+  english: I am a college graduate.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 地方
+    pinyin: dì fāng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 。
+    pinyin: ''
+  english: This place is very beautiful.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 地方
+    pinyin: dì fāng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 安静
+    pinyin: ān jìng
+  - chinese: 。
+    pinyin: ''
+  english: This place is very quiet.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 地方
+    pinyin: dì fāng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 热闹
+    pinyin: rè nao
+  - chinese: 。
+    pinyin: ''
+  english: This place is very lively.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 地方
+    pinyin: dì fāng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 安全
+    pinyin: ān quán
+  - chinese: 。
+    pinyin: ''
+  english: This place is very safe.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 确定
+    pinyin: què dìng
+  - chinese: 会议
+    pinyin: huì yì
+  - chinese: 的
+    pinyin: de
+  - chinese: 地点
+    pinyin: dì diǎn
+  - chinese: 。
+    pinyin: ''
+  english: We need to determine the location of the meeting.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 事件
+    pinyin: shì jiàn
+  - chinese: 发生
+    pinyin: fā shēng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪
+    pinyin: nǎ
+  - chinese: 个
+    pinyin: gè
+  - chinese: 地点
+    pinyin: dì diǎn
+  - chinese: ？
+    pinyin: ''
+  english: Where did this incident happen?
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 告诉
+    pinyin: gào sù
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 最近
+    pinyin: zuì jìn
+  - chinese: 的
+    pinyin: de
+  - chinese: 图书馆
+    pinyin: tú shū guǎn
+  - chinese: 地点
+    pinyin: dì diǎn
+  - chinese: 。
+    pinyin: ''
+  english: Please tell me the location of the nearest library.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 餐厅
+    pinyin: cān tīng
+  - chinese: 的
+    pinyin: de
+  - chinese: 地点
+    pinyin: dì diǎn
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: ？
+    pinyin: ''
+  english: Where is the location of this restaurant?
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 告诉
+    pinyin: gào sù
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 最近
+    pinyin: zuì jìn
+  - chinese: 的
+    pinyin: de
+  - chinese: 医院
+    pinyin: yī yuàn
+  - chinese: 地点
+    pinyin: dì diǎn
+  - chinese: 。
+    pinyin: ''
+  english: Please tell me the location of the nearest hospital.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 的
+    pinyin: de
+  - chinese: 地点
+    pinyin: dì diǎn
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: ？
+    pinyin: ''
+  english: Where is the location of this park?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 忘记
+    pinyin: wàng jì
+  - chinese: 了
+    pinyin: le
+  - chinese: 约定
+    pinyin: yuē dìng
+  - chinese: 的
+    pinyin: de
+  - chinese: 地点
+    pinyin: dì diǎn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 所以
+    pinyin: suǒ yǐ
+  - chinese: 迟到
+    pinyin: chí dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: He forgot the location of the appointment, so he was late.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 确定
+    pinyin: què dìng
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 项目
+    pinyin: xiàng mù
+  - chinese: 的
+    pinyin: de
+  - chinese: 地点
+    pinyin: dì diǎn
+  - chinese: 。
+    pinyin: ''
+  english: We need to determine the location of this project.
+
+- segments:
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 去
+    pinyin: qù
+  - chinese: 的
+    pinyin: de
+  - chinese: 地点
+    pinyin: dì diǎn
+  - chinese: 。
+    pinyin: ''
+  english: School is the place I go to every day.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 在
+    pinyin: zài
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 的
+    pinyin: de
+  - chinese: 某
+    pinyin: mǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 安静
+    pinyin: ān jìng
+  - chinese: 地点
+    pinyin: dì diǎn
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I like to read books in a quiet spot in the park.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 书
+    pinyin: shū
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 地上
+    pinyin: dì shang
+  - chinese: 。
+    pinyin: ''
+  english: He put the book on the ground.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 地上
+    pinyin: dì shang
+  - chinese: 捡
+    pinyin: jiǎn
+  - chinese: 到
+    pinyin: dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 钱包
+    pinyin: qián bāo
+  - chinese: 。
+    pinyin: ''
+  english: She found a wallet on the ground.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 地上
+    pinyin: dì shang
+  - chinese: 看到
+    pinyin: kàn dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 小猫
+    pinyin: xiǎo māo
+  - chinese: 。
+    pinyin: ''
+  english: I saw a kitten on the ground.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 垃圾
+    pinyin: lā jī
+  - chinese: 扔
+    pinyin: rēng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 地上
+    pinyin: dì shang
+  - chinese: 。
+    pinyin: ''
+  english: He threw the trash on the ground.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 地上
+    pinyin: dì shang
+  - chinese: 发现
+    pinyin: fā xiàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 朵
+    pinyin: duǒ
+  - chinese: 花
+    pinyin: huā
+  - chinese: 。
+    pinyin: ''
+  english: She found a flower on the ground.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 地上
+    pinyin: dì shang
+  - chinese: 看到
+    pinyin: kàn dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 小鸟
+    pinyin: xiǎo niǎo
+  - chinese: 。
+    pinyin: ''
+  english: I saw a little bird on the ground.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 泼
+    pinyin: pō
+  - chinese: 在
+    pinyin: zài
+  - chinese: 地上
+    pinyin: dì shang
+  - chinese: 。
+    pinyin: ''
+  english: He spilled water on the ground.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 地上
+    pinyin: dì shang
+  - chinese: 看到
+    pinyin: kàn dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 蝴蝶
+    pinyin: hú dié
+  - chinese: 。
+    pinyin: ''
+  english: She saw a butterfly on the ground.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 地上
+    pinyin: dì shang
+  - chinese: 看到
+    pinyin: kàn dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 小狗
+    pinyin: xiǎo gǒu
+  - chinese: 。
+    pinyin: ''
+  english: I saw a little dog on the ground.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 石头
+    pinyin: shí tou
+  - chinese: 扔
+    pinyin: rēng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 地上
+    pinyin: dì shang
+  - chinese: 。
+    pinyin: ''
+  english: He threw a stone on the ground.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 地上
+    pinyin: dì shang
+  - chinese: 看到
+    pinyin: kàn dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 昆虫
+    pinyin: kūn chóng
+  - chinese: 。
+    pinyin: ''
+  english: She saw an insect on the ground.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 地图
+    pinyin: dì tú
+  - chinese: 。
+    pinyin: ''
+  english: I need a map.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 地图
+    pinyin: dì tú
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 城市
+    pinyin: chéng shì
+  - chinese: 。
+    pinyin: ''
+  english: This map does not have this city.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 详细
+    pinyin: xiáng xì
+  - chinese: 的
+    pinyin: de
+  - chinese: 地图
+    pinyin: dì tú
+  - chinese: 。
+    pinyin: ''
+  english: I need a detailed map.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 地图
+    pinyin: dì tú
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 标
+    pinyin: biāo
+  - chinese: 出
+    pinyin: chū
+  - chinese: 了
+    pinyin: le
+  - chinese: 所有
+    pinyin: suǒ yǒu
+  - chinese: 的
+    pinyin: de
+  - chinese: 景点
+    pinyin: jǐng diǎn
+  - chinese: 。
+    pinyin: ''
+  english: This map marks all the scenic spots.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 城市
+    pinyin: chéng shì
+  - chinese: 地图
+    pinyin: dì tú
+  - chinese: 。
+    pinyin: ''
+  english: I need a city map.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 地图
+    pinyin: dì tú
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 标
+    pinyin: biāo
+  - chinese: 出
+    pinyin: chū
+  - chinese: 了
+    pinyin: le
+  - chinese: 所有
+    pinyin: suǒ yǒu
+  - chinese: 的
+    pinyin: de
+  - chinese: 地铁站
+    pinyin: dì tiě zhàn
+  - chinese: 。
+    pinyin: ''
+  english: This map marks all the subway stations.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 旅游
+    pinyin: lǚ yóu
+  - chinese: 地图
+    pinyin: dì tú
+  - chinese: 。
+    pinyin: ''
+  english: I need a tourist map.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 地图
+    pinyin: dì tú
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 标
+    pinyin: biāo
+  - chinese: 出
+    pinyin: chū
+  - chinese: 了
+    pinyin: le
+  - chinese: 所有
+    pinyin: suǒ yǒu
+  - chinese: 的
+    pinyin: de
+  - chinese: 高速
+    pinyin: gāo sù
+  - chinese: 公路
+    pinyin: gōng lù
+  - chinese: 。
+    pinyin: ''
+  english: This map marks all the highways.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 地铁
+    pinyin: dì tiě
+  - chinese: 地图
+    pinyin: dì tú
+  - chinese: 。
+    pinyin: ''
+  english: I need a subway map.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 地图
+    pinyin: dì tú
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 标
+    pinyin: biāo
+  - chinese: 出
+    pinyin: chū
+  - chinese: 了
+    pinyin: le
+  - chinese: 所有
+    pinyin: suǒ yǒu
+  - chinese: 的
+    pinyin: de
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 。
+    pinyin: ''
+  english: This map marks all the parks.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 公交
+    pinyin: gōng jiāo
+  - chinese: 地图
+    pinyin: dì tú
+  - chinese: 。
+    pinyin: ''
+  english: I need a bus map.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 台
+    pinyin: tái
+  - chinese: 电视机
+    pinyin: diàn shì jī
+  - chinese: 。
+    pinyin: ''
+  english: We have a TV at home.
+
+- segments:
+  - chinese: 电视机
+    pinyin: diàn shì jī
+  - chinese: 坏
+    pinyin: huài
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 修理
+    pinyin: xiū lǐ
+  - chinese: 。
+    pinyin: ''
+  english: The TV is broken and needs to be repaired.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 一
+    pinyin: yī
+  - chinese: 台
+    pinyin: tái
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 的
+    pinyin: de
+  - chinese: 电视机
+    pinyin: diàn shì jī
+  - chinese: 。
+    pinyin: ''
+  english: We need to buy a new TV.
+
+- segments:
+  - chinese: 电视机
+    pinyin: diàn shì jī
+  - chinese: 的
+    pinyin: de
+  - chinese: 遥控器
+    pinyin: yáo kòng qì
+  - chinese: 不见了
+    pinyin: bù jiàn le
+  - chinese: 。
+    pinyin: ''
+  english: The TV remote control is missing.
+
+- segments:
+  - chinese: 电视机
+    pinyin: diàn shì jī
+  - chinese: 的
+    pinyin: de
+  - chinese: 频道
+    pinyin: pín dào
+  - chinese: 坏
+    pinyin: huài
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: The TV channel is broken.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 电视机
+    pinyin: diàn shì jī
+  - chinese: 搬
+    pinyin: bān
+  - chinese: 到
+    pinyin: dào
+  - chinese: 另
+    pinyin: lìng
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 。
+    pinyin: ''
+  english: We need to move the TV to another room.
+
+- segments:
+  - chinese: 电视机
+    pinyin: diàn shì jī
+  - chinese: 的
+    pinyin: de
+  - chinese: 音量
+    pinyin: yīn liàng
+  - chinese: 太
+    pinyin: tài
+  - chinese: 大
+    pinyin: dà
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: The TV volume is too loud.
+
+- segments:
+  - chinese: 电视机
+    pinyin: diàn shì jī
+  - chinese: 的
+    pinyin: de
+  - chinese: 屏幕
+    pinyin: píng mù
+  - chinese: 坏
+    pinyin: huài
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: The TV screen is broken.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 电视机
+    pinyin: diàn shì jī
+  - chinese: 的
+    pinyin: de
+  - chinese: 电线
+    pinyin: diàn xiàn
+  - chinese: 插
+    pinyin: chā
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: We need to plug in the TV cable.
+
+- segments:
+  - chinese: 电视机
+    pinyin: diàn shì jī
+  - chinese: 的
+    pinyin: de
+  - chinese: 信号
+    pinyin: xìn hào
+  - chinese: 不
+    pinyin: bù
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: The TV signal is not good.
+
+- segments:
+  - chinese: 太阳
+    pinyin: tài yang
+  - chinese: 从
+    pinyin: cóng
+  - chinese: 东边
+    pinyin: dōng bian
+  - chinese: 升起
+    pinyin: shēng qǐ
+  - chinese: 。
+    pinyin: ''
+  english: The sun rises in the east.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 住
+    pinyin: zhù
+  - chinese: 的
+    pinyin: de
+  - chinese: 公
+    pinyin: gōng
+  - chinese: 寓
+    pinyin: yù
+  - chinese: 在
+    pinyin: zài
+  - chinese: 东边
+    pinyin: dōng bian
+  - chinese: 。
+    pinyin: ''
+  english: Our apartment is on the east side.
+
+- segments:
+  - chinese: 东边
+    pinyin: dōng bian
+  - chinese: 的
+    pinyin: de
+  - chinese: 天空
+    pinyin: tiān kōng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 红
+    pinyin: hóng
+  - chinese: 色
+    pinyin: sè
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: The sky in the east is red.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 要
+    pinyin: yào
+  - chinese: 往
+    pinyin: wǎng
+  - chinese: 东边
+    pinyin: dōng bian
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 。
+    pinyin: ''
+  english: We need to go east.
+
+- segments:
+  - chinese: 东边
+    pinyin: dōng bian
+  - chinese: 的
+    pinyin: de
+  - chinese: 街
+    pinyin: jiē
+  - chinese: 道
+    pinyin: dào
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 繁
+    pinyin: fán
+  - chinese: 华
+    pinyin: huá
+  - chinese: 。
+    pinyin: ''
+  english: The streets on the east side are very bustling.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 东边
+    pinyin: dōng bian
+  - chinese: 的
+    pinyin: de
+  - chinese: 公
+    pinyin: gōng
+  - chinese: 园
+    pinyin: yuán
+  - chinese: 散
+    pinyin: sàn
+  - chinese: 步
+    pinyin: bù
+  - chinese: 。
+    pinyin: ''
+  english: We are going to take a walk in the park on the east side.
+
+- segments:
+  - chinese: 东边
+    pinyin: dōng bian
+  - chinese: 的
+    pinyin: de
+  - chinese: 海滩
+    pinyin: hǎi tān
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 美
+    pinyin: měi
+  - chinese: 。
+    pinyin: ''
+  english: The beach on the east side is beautiful.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 要
+    pinyin: yào
+  - chinese: 向
+    pinyin: xiàng
+  - chinese: 东边
+    pinyin: dōng bian
+  - chinese: 的
+    pinyin: de
+  - chinese: 机场
+    pinyin: jī chǎng
+  - chinese: 出发
+    pinyin: chū fā
+  - chinese: 。
+    pinyin: ''
+  english: We need to head to the airport on the east side.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 久
+    pinyin: jiǔ
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 不
+    pinyin: bù
+  - chinese: 动
+    pinyin: dòng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 屁股
+    pinyin: pì gu
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 麻
+    pinyin: má
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: She sat for too long and her butt went numb.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 个
+    pinyin: gè
+  - chinese: 好动
+    pinyin: hào dòng
+  - chinese: 的
+    pinyin: de
+  - chinese: 人
+    pinyin: rén
+  - chinese: ，
+    pinyin: ''
+  - chinese: 总
+    pinyin: zǒng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 到
+    pinyin: dào
+  - chinese: 处
+    pinyin: chù
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 。
+    pinyin: ''
+  english: He is an active person who likes to walk around everywhere.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 动
+    pinyin: dòng
+  - chinese: 动
+    pinyin: dòng
+  - chinese: 脑
+    pinyin: nǎo
+  - chinese: 筋
+    pinyin: jīn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 出
+    pinyin: chū
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 主
+    pinyin: zhǔ
+  - chinese: 意
+    pinyin: yì
+  - chinese: 。
+    pinyin: ''
+  english: We need to use our brains and come up with a good idea.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 总
+    pinyin: zǒng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 不动声色
+    pinyin: bù dòng shēng sè
+  - chinese: 地
+    pinyin: de
+  - chinese: 观
+    pinyin: guān
+  - chinese: 察
+    pinyin: chá
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 周
+    pinyin: zhōu
+  - chinese: 围
+    pinyin: wéi
+  - chinese: 的
+    pinyin: de
+  - chinese: 一
+    pinyin: yī
+  - chinese: 切
+    pinyin: qiè
+  - chinese: 。
+    pinyin: ''
+  english: He always observes everything around him without showing any emotion.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 个
+    pinyin: gè
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 动
+    pinyin: dòng
+  - chinese: 的
+    pinyin: de
+  - chinese: 人
+    pinyin: rén
+  - chinese: ，
+    pinyin: ''
+  - chinese: 总
+    pinyin: zǒng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 运动
+    pinyin: yùn dòng
+  - chinese: 。
+    pinyin: ''
+  english: He is an active person who likes to exercise.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 个
+    pinyin: gè
+  - chinese: 不
+    pinyin: bù
+  - chinese: 爱
+    pinyin: ài
+  - chinese: 动
+    pinyin: dòng
+  - chinese: 的
+    pinyin: de
+  - chinese: 人
+    pinyin: rén
+  - chinese: ，
+    pinyin: ''
+  - chinese: 总
+    pinyin: zǒng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 宅
+    pinyin: zhái
+  - chinese: 在
+    pinyin: zài
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 。
+    pinyin: ''
+  english: She is an inactive person who likes to stay at home.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 动
+    pinyin: dòng
+  - chinese: 动
+    pinyin: dòng
+  - chinese: 手
+    pinyin: shǒu
+  - chinese: 指
+    pinyin: zhǐ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 完
+    pinyin: wán
+  - chinese: 成
+    pinyin: chéng
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 任
+    pinyin: rèn
+  - chinese: 务
+    pinyin: wù
+  - chinese: 。
+    pinyin: ''
+  english: We need to move our fingers and complete this task.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 个
+    pinyin: gè
+  - chinese: 爱
+    pinyin: ài
+  - chinese: 动
+    pinyin: dòng
+  - chinese: 的
+    pinyin: de
+  - chinese: 人
+    pinyin: rén
+  - chinese: ，
+    pinyin: ''
+  - chinese: 总
+    pinyin: zǒng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 尝试
+    pinyin: cháng shì
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 的
+    pinyin: de
+  - chinese: 事物
+    pinyin: shì wù
+  - chinese: 。
+    pinyin: ''
+  english: He is an active person who likes to try new things.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 的
+    pinyin: de
+  - chinese: 动作
+    pinyin: dòng zuò
+  - chinese: ，
+    pinyin: ''
+  - chinese: 赢
+    pinyin: yíng
+  - chinese: 得了
+    pinyin: dé le
+  - chinese: 观众
+    pinyin: guān zhòng
+  - chinese: 的
+    pinyin: de
+  - chinese: 掌声
+    pinyin: zhǎng shēng
+  - chinese: 。
+    pinyin: ''
+  english: He made a beautiful move and won applause from the audience.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 学
+    pinyin: xué
+  - chinese: 习
+    pinyin: xí
+  - chinese: 一些
+    pinyin: yī xiē
+  - chinese: 基本
+    pinyin: jī běn
+  - chinese: 的
+    pinyin: de
+  - chinese: 动作
+    pinyin: dòng zuò
+  - chinese: ，
+    pinyin: ''
+  - chinese: 才
+    pinyin: cái
+  - chinese: 能
+    pinyin: néng
+  - chinese: 更
+    pinyin: gèng
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 地
+    pinyin: de
+  - chinese: 跳舞
+    pinyin: tiào wǔ
+  - chinese: 。
+    pinyin: ''
+  english: We need to learn some basic moves to dance better.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 舞蹈
+    pinyin: wǔ dǎo
+  - chinese: 动作
+    pinyin: dòng zuò
+  - chinese: 非常
+    pinyin: fēi cháng
+  - chinese: 优
+    pinyin: yōu
+  - chinese: 美
+    pinyin: měi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 让
+    pinyin: ràng
+  - chinese: 人
+    pinyin: rén
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 得
+    pinyin: dé
+  - chinese: 入
+    pinyin: rù
+  - chinese: 迷
+    pinyin: mí
+  - chinese: 。
+    pinyin: ''
+  english: Her dance moves are very beautiful and captivating.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 危险
+    pinyin: wēi xiǎn
+  - chinese: 的
+    pinyin: de
+  - chinese: 动作
+    pinyin: dòng zuò
+  - chinese: ，
+    pinyin: ''
+  - chinese: 差点
+    pinyin: chà diǎn
+  - chinese: 摔
+    pinyin: shuāi
+  - chinese: 倒
+    pinyin: dǎo
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: He made a dangerous move and almost fell.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 学
+    pinyin: xué
+  - chinese: 习
+    pinyin: xí
+  - chinese: 一些
+    pinyin: yī xiē
+  - chinese: 基本
+    pinyin: jī běn
+  - chinese: 的
+    pinyin: de
+  - chinese: 武术
+    pinyin: wǔ shù
+  - chinese: 动作
+    pinyin: dòng zuò
+  - chinese: ，
+    pinyin: ''
+  - chinese: 才
+    pinyin: cái
+  - chinese: 能
+    pinyin: néng
+  - chinese: 更
+    pinyin: gèng
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 地
+    pinyin: de
+  - chinese: 保护
+    pinyin: bǎo hù
+  - chinese: 自己
+    pinyin: zì jǐ
+  - chinese: 。
+    pinyin: ''
+  english: We must learn some basic martial arts moves to protect ourselves better.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 舞蹈
+    pinyin: wǔ dǎo
+  - chinese: 动作
+    pinyin: dòng zuò
+  - chinese: 非常
+    pinyin: fēi cháng
+  - chinese: 流
+    pinyin: liú
+  - chinese: 畅
+    pinyin: chàng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 让
+    pinyin: ràng
+  - chinese: 人
+    pinyin: rén
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 得
+    pinyin: dé
+  - chinese: 非常
+    pinyin: fēi cháng
+  - chinese: 舒服
+    pinyin: shū fu
+  - chinese: 。
+    pinyin: ''
+  english: Her dance moves are very smooth and comfortable to watch.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 动作
+    pinyin: dòng zuò
+  - chinese: 非常
+    pinyin: fēi cháng
+  - chinese: 敏捷
+    pinyin: mǐn jié
+  - chinese: ，
+    pinyin: ''
+  - chinese: 让
+    pinyin: ràng
+  - chinese: 人
+    pinyin: rén
+  - chinese: 惊叹
+    pinyin: jīng tàn
+  - chinese: 不已
+    pinyin: bù yǐ
+  - chinese: 。
+    pinyin: ''
+  english: His moves are very agile, making people amazed.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 放假
+    pinyin: fàng jià
+  - chinese: 的
+    pinyin: de
+  - chinese: 日子
+    pinyin: rì zi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 休息
+    pinyin: xiū xi
+  - chinese: 一
+    pinyin: yī
+  - chinese: 下
+    pinyin: xià
+  - chinese: 。
+    pinyin: ''
+  english: Today is a holiday, we can take a good rest.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 公司
+    pinyin: gōng sī
+  - chinese: 放假
+    pinyin: fàng jià
+  - chinese: 三
+    pinyin: sān
+  - chinese: 天
+    pinyin: tiān
+  - chinese: ，
+    pinyin: ''
+  - chinese: 大家
+    pinyin: dà jiā
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 放松
+    pinyin: fàng sōng
+  - chinese: 一
+    pinyin: yī
+  - chinese: 下
+    pinyin: xià
+  - chinese: 。
+    pinyin: ''
+  english: Our company has a three-day holiday, everyone can relax.
+
+- segments:
+  - chinese: 放假
+    pinyin: fàng jià
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 旅游
+    pinyin: lǚ yóu
+  - chinese: 或者
+    pinyin: huò zhě
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: During the holiday, we can travel or watch movies.
+
+- segments:
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 干净
+    pinyin: gān jìng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 没
+    pinyin: méi
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 任何
+    pinyin: rèn hé
+  - chinese: 杂物
+    pinyin: zá wù
+  - chinese: 。
+    pinyin: ''
+  english: The room is very clean, without any clutter.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 打扫
+    pinyin: dǎ sǎo
+  - chinese: 干净
+    pinyin: gān jìng
+  - chinese: 。
+    pinyin: ''
+  english: We need to clean up the room.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 的
+    pinyin: de
+  - chinese: 公司
+    pinyin: gōng sī
+  - chinese: 环境
+    pinyin: huán jìng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 干净
+    pinyin: gān jìng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 让
+    pinyin: ràng
+  - chinese: 人
+    pinyin: rén
+  - chinese: 感到
+    pinyin: gǎn dào
+  - chinese: 舒适
+    pinyin: shū shì
+  - chinese: 。
+    pinyin: ''
+  english: Our company environment is very clean, making people feel comfortable.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 干净
+    pinyin: gān jìng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 任何
+    pinyin: rèn hé
+  - chinese: 污点
+    pinyin: wū diǎn
+  - chinese: 。
+    pinyin: ''
+  english: Her clothes are very clean, without any stains.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 的
+    pinyin: de
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 收拾
+    pinyin: shōu shi
+  - chinese: 干净
+    pinyin: gān jìng
+  - chinese: 。
+    pinyin: ''
+  english: We need to tidy up the things on the table.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 干净
+    pinyin: gān jìng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 任何
+    pinyin: rèn hé
+  - chinese: 杂物
+    pinyin: zá wù
+  - chinese: 。
+    pinyin: ''
+  english: His room is very clean, without any clutter.
+
+- segments:
+  - chinese: 工人
+    pinyin: gōng rén
+  - chinese: 们
+    pinyin: men
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 修路
+    pinyin: xiū lù
+  - chinese: 。
+    pinyin: ''
+  english: The workers are repairing the road.
+
+- segments:
+  - chinese: 工人
+    pinyin: gōng rén
+  - chinese: 们
+    pinyin: men
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 建设
+    pinyin: jiàn shè
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 的
+    pinyin: de
+  - chinese: 房子
+    pinyin: fáng zi
+  - chinese: 。
+    pinyin: ''
+  english: The workers are building a new house.
+
+- segments:
+  - chinese: 工人
+    pinyin: gōng rén
+  - chinese: 们
+    pinyin: men
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 修理
+    pinyin: xiū lǐ
+  - chinese: 电梯
+    pinyin: diàn tī
+  - chinese: 。
+    pinyin: ''
+  english: The workers are repairing the elevator.
+
+- segments:
+  - chinese: 工人
+    pinyin: gōng rén
+  - chinese: 们
+    pinyin: men
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 修理
+    pinyin: xiū lǐ
+  - chinese: 水管
+    pinyin: shuǐ guǎn
+  - chinese: 。
+    pinyin: ''
+  english: The workers are repairing the water pipe.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 关上
+    pinyin: guān shàng
+  - chinese: 窗户
+    pinyin: chuāng hu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 外面
+    pinyin: wài miàn
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 。
+    pinyin: ''
+  english: Please close the window, it's very cold outside.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 关上
+    pinyin: guān shàng
+  - chinese: 门
+    pinyin: mén
+  - chinese: ，
+    pinyin: ''
+  - chinese: 保持
+    pinyin: bǎo chí
+  - chinese: 室内
+    pinyin: shì nèi
+  - chinese: 的
+    pinyin: de
+  - chinese: 温暖
+    pinyin: wēn nuǎn
+  - chinese: 。
+    pinyin: ''
+  english: We need to close the door to keep the room warm.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 关上
+    pinyin: guān shàng
+  - chinese: 灯
+    pinyin: dēng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 要
+    pinyin: yào
+  - chinese: 睡觉
+    pinyin: shuì jiào
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: Please turn off the lights, we're going to sleep.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 关上
+    pinyin: guān shàng
+  - chinese: 窗户
+    pinyin: chuāng hu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 避免
+    pinyin: bì miǎn
+  - chinese: 外面
+    pinyin: wài miàn
+  - chinese: 的
+    pinyin: de
+  - chinese: 尘埃
+    pinyin: chén āi
+  - chinese: 进入
+    pinyin: jìn rù
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 。
+    pinyin: ''
+  english: We need to close the window to prevent outside dust from entering the room.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 公司
+    pinyin: gōng sī
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 许多
+    pinyin: xǔ duō
+  - chinese: 国外
+    pinyin: guó wài
+  - chinese: 的
+    pinyin: de
+  - chinese: 客户
+    pinyin: kè hù
+  - chinese: 。
+    pinyin: ''
+  english: Our company has many foreign customers.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 学
+    pinyin: xué
+  - chinese: 习
+    pinyin: xí
+  - chinese: 国外
+    pinyin: guó wài
+  - chinese: 的
+    pinyin: de
+  - chinese: 先进
+    pinyin: xiān jìn
+  - chinese: 技术
+    pinyin: jì shù
+  - chinese: 。
+    pinyin: ''
+  english: We need to learn advanced technology from abroad.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 公司
+    pinyin: gōng sī
+  - chinese: 的
+    pinyin: de
+  - chinese: 产品
+    pinyin: chǎn pǐn
+  - chinese: 在
+    pinyin: zài
+  - chinese: 国外
+    pinyin: guó wài
+  - chinese: 也
+    pinyin: yě
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 受欢迎
+    pinyin: shòu huān yíng
+  - chinese: 。
+    pinyin: ''
+  english: Our company's products are also very popular abroad.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 的
+    pinyin: de
+  - chinese: 国家
+    pinyin: guó jiā
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 经历
+    pinyin: jīng lì
+  - chinese: 大
+    pinyin: dà
+  - chinese: 变革
+    pinyin: biàn gé
+  - chinese: 。
+    pinyin: ''
+  english: Our country is undergoing major changes.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 保护
+    pinyin: bǎo hù
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 的
+    pinyin: de
+  - chinese: 国家
+    pinyin: guó jiā
+  - chinese: 。
+    pinyin: ''
+  english: We need to protect our country.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 的
+    pinyin: de
+  - chinese: 国家
+    pinyin: guó jiā
+  - chinese: 有着
+    pinyin: yǒu zhe
+  - chinese: 悠久
+    pinyin: yōu jiǔ
+  - chinese: 的
+    pinyin: de
+  - chinese: 历史
+    pinyin: lì shǐ
+  - chinese: 和
+    pinyin: hé
+  - chinese: 文化
+    pinyin: wén huà
+  - chinese: 。
+    pinyin: ''
+  english: Our country has a long history and culture.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 一直
+    pinyin: yī zhí
+  - chinese: 在
+    pinyin: zài
+  - chinese: 为
+    pinyin: wèi
+  - chinese: 考试
+    pinyin: kǎo shì
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 。
+    pinyin: ''
+  english: He has been preparing for the exam.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 带
+    pinyin: dài
+  - chinese: 去
+    pinyin: qù
+  - chinese: 野餐
+    pinyin: yě cān
+  - chinese: 。
+    pinyin: ''
+  english: We should prepare some things to take for a picnic.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 惊喜
+    pinyin: jīng xǐ
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 男朋友
+    pinyin: nán péng you
+  - chinese: 。
+    pinyin: ''
+  english: I want to prepare a surprise for my boyfriend.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 生日
+    pinyin: shēng rì
+  - chinese: 惊喜
+    pinyin: jīng xǐ
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 姐姐
+    pinyin: jiě jie
+  - chinese: 。
+    pinyin: ''
+  english: I am preparing a birthday surprise for my sister.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 为
+    pinyin: wèi
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 些
+    pinyin: xiē
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 。
+    pinyin: ''
+  english: We should prepare for the trip.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 为
+    pinyin: wèi
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 演讲
+    pinyin: yǎn jiǎng
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 了
+    pinyin: le
+  - chinese: 多
+    pinyin: duō
+  - chinese: 久
+    pinyin: jiǔ
+  - chinese: ？
+    pinyin: ''
+  english: How long have you been preparing for your speech?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 餐厅
+    pinyin: cān tīng
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 了
+    pinyin: le
+  - chinese: 美味
+    pinyin: měi wèi
+  - chinese: 的
+    pinyin: de
+  - chinese: 素食
+    pinyin: sù shí
+  - chinese: 菜肴
+    pinyin: cài yáo
+  - chinese: 。
+    pinyin: ''
+  english: This restaurant prepared delicious vegetarian dishes.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 这些
+    pinyin: zhè xiē
+  - chinese: 材料
+    pinyin: cái liào
+  - chinese: 的
+    pinyin: de
+  - chinese: ？
+    pinyin: ''
+  english: How did you prepare these materials?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 饭菜
+    pinyin: fàn cài
+  - chinese: 。
+    pinyin: ''
+  english: I am preparing the meal.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 了
+    pinyin: le
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Are you ready?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 考试
+    pinyin: kǎo shì
+  - chinese: 。
+    pinyin: ''
+  english: I need to prepare for the exam.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 饭
+    pinyin: fàn
+  - chinese: 。
+    pinyin: ''
+  english: She is preparing dinner.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What are you preparing?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 在
+    pinyin: zài
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 走路
+    pinyin: zǒu lù
+  - chinese: 。
+    pinyin: ''
+  english: I enjoy walking in the park.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 走路
+    pinyin: zǒu lù
+  - chinese: 去
+    pinyin: qù
+  - chinese: 上班
+    pinyin: shàng bān
+  - chinese: 。
+    pinyin: ''
+  english: He walks to work every day.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 走路
+    pinyin: zǒu lù
+  - chinese: 去
+    pinyin: qù
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 。
+    pinyin: ''
+  english: We walk to school together.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 不
+    pinyin: bù
+  - chinese: 走路
+    pinyin: zǒu lù
+  - chinese: 去
+    pinyin: qù
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: ？
+    pinyin: ''
+  english: Why don't you walk to the store?
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 边
+    pinyin: biān
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 音乐
+    pinyin: yīn yuè
+  - chinese: 边
+    pinyin: biān
+  - chinese: 走路
+    pinyin: zǒu lù
+  - chinese: 。
+    pinyin: ''
+  english: She walks while listening to music.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 坐下
+    pinyin: zuò xia
+  - chinese: 来
+    pinyin: lái
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 早饭
+    pinyin: zǎo fàn
+  - chinese: 。
+    pinyin: ''
+  english: He sat down to eat breakfast.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 坐下
+    pinyin: zuò xia
+  - chinese: 来
+    pinyin: lái
+  - chinese: 讨论
+    pinyin: tǎo lùn
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 。
+    pinyin: ''
+  english: They sat down to discuss the issue.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 不
+    pinyin: bù
+  - chinese: 坐下
+    pinyin: zuò xia
+  - chinese: 休息
+    pinyin: xiū xi
+  - chinese: 一下
+    pinyin: yī xià
+  - chinese: ？
+    pinyin: ''
+  english: Why don't you sit down and take a rest?
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 累
+    pinyin: lèi
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 坐下
+    pinyin: zuò xia
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: She was tired, so she sat down.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 名
+    pinyin: míng
+  - chinese: 中学生
+    pinyin: zhōng xué shēng
+  - chinese: 。
+    pinyin: ''
+  english: I am a middle school student.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 男孩
+    pinyin: nán hái
+  - chinese: 是
+    pinyin: shì
+  - chinese: 中学生
+    pinyin: zhōng xué shēng
+  - chinese: 。
+    pinyin: ''
+  english: That boy is a middle school student.
+
+- segments:
+  - chinese: 这些
+    pinyin: zhè xiē
+  - chinese: 书
+    pinyin: shū
+  - chinese: 适合
+    pinyin: shì hé
+  - chinese: 中学生
+    pinyin: zhōng xué shēng
+  - chinese: 阅读
+    pinyin: yuè dú
+  - chinese: 。
+    pinyin: ''
+  english: These books are suitable for middle school students to read.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 弟弟
+    pinyin: dì di
+  - chinese: 是
+    pinyin: shì
+  - chinese: 中学生
+    pinyin: zhōng xué shēng
+  - chinese: 。
+    pinyin: ''
+  english: My younger brother is a middle school student.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 是
+    pinyin: shì
+  - chinese: 中学生
+    pinyin: zhōng xué shēng
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Are you a middle school student?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 了
+    pinyin: le
+  - chinese: 一半
+    pinyin: yī bàn
+  - chinese: 的
+    pinyin: de
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: I ate half of the apple.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 份
+    pinyin: fèn
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 已经
+    pinyin: yǐ jīng
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 了
+    pinyin: le
+  - chinese: 大半
+    pinyin: dà bàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I have done most of this work.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 蛋糕
+    pinyin: dàn gāo
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 吃
+    pinyin: chī
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 一半
+    pinyin: yī bàn
+  - chinese: 。
+    pinyin: ''
+  english: Please have some cake; you can have half of it.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 花
+    pinyin: huā
+  - chinese: 了
+    pinyin: le
+  - chinese: 大半
+    pinyin: dà bàn
+  - chinese: 天
+    pinyin: tiān
+  - chinese: 的
+    pinyin: de
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 打扫
+    pinyin: dǎ sǎo
+  - chinese: 房子
+    pinyin: fáng zi
+  - chinese: 。
+    pinyin: ''
+  english: I spent most of the day cleaning the house.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 已经
+    pinyin: yǐ jīng
+  - chinese: 读
+    pinyin: dú
+  - chinese: 了
+    pinyin: le
+  - chinese: 一半
+    pinyin: yī bàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I have read half of this book.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 有名
+    pinyin: yǒu míng
+  - chinese: 的
+    pinyin: de
+  - chinese: 演员
+    pinyin: yǎn yuán
+  - chinese: 之
+    pinyin: zhī
+  - chinese: 一
+    pinyin: yī
+  - chinese: 。
+    pinyin: ''
+  english: He is one of the most famous actors.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 餐厅
+    pinyin: cān tīng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有名
+    pinyin: yǒu míng
+  - chinese: 。
+    pinyin: ''
+  english: This restaurant is very famous.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 世界
+    pinyin: shì jiè
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 有名
+    pinyin: yǒu míng
+  - chinese: 的
+    pinyin: de
+  - chinese: 歌手
+    pinyin: gē shǒu
+  - chinese: 之
+    pinyin: zhī
+  - chinese: 一
+    pinyin: yī
+  - chinese: 。
+    pinyin: ''
+  english: She is one of the most famous singers in the world.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 幅
+    pinyin: fú
+  - chinese: 画
+    pinyin: huà
+  - chinese: 的
+    pinyin: de
+  - chinese: 画家
+    pinyin: huà jiā
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有名
+    pinyin: yǒu míng
+  - chinese: 。
+    pinyin: ''
+  english: The painter of this painting is very famous.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有没有
+    pinyin: yǒu méi yǒu
+  - chinese: 听说
+    pinyin: tīng shuō
+  - chinese: 过
+    pinyin: guò
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有名
+    pinyin: yǒu míng
+  - chinese: 的
+    pinyin: de
+  - chinese: 作家
+    pinyin: zuò jiā
+  - chinese: ？
+    pinyin: ''
+  english: Have you ever heard of that famous writer?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 离
+    pinyin: lí
+  - chinese: 这里
+    pinyin: zhè lǐ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 远
+    pinyin: yuǎn
+  - chinese: 。
+    pinyin: ''
+  english: His home is far from here.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 远远
+    pinyin: yuǎn yuǎn
+  - chinese: 地
+    pinyin: dì
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 车祸
+    pinyin: chē huò
+  - chinese: 。
+    pinyin: ''
+  english: They watched the car accident from a distance.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 座
+    pinyin: zuò
+  - chinese: 山
+    pinyin: shān
+  - chinese: 离
+    pinyin: lí
+  - chinese: 城市
+    pinyin: chéng shì
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 远
+    pinyin: yuǎn
+  - chinese: 。
+    pinyin: ''
+  english: This mountain is far from the city.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 远远
+    pinyin: yuǎn yuǎn
+  - chinese: 地
+    pinyin: dì
+  - chinese: 互相
+    pinyin: hù xiāng
+  - chinese: 望
+    pinyin: wàng
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 。
+    pinyin: ''
+  english: They gazed at each other from a distance.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 事情
+    pinyin: shì qing
+  - chinese: 对
+    pinyin: duì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 来
+    pinyin: lái
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 是
+    pinyin: shì
+  - chinese: 远
+    pinyin: yuǎn
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: This matter is distant to me.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 终于
+    pinyin: zhōng yú
+  - chinese: 找到
+    pinyin: zhǎo dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 钥匙
+    pinyin: yào shi
+  - chinese: 。
+    pinyin: ''
+  english: I finally found my keys.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 找到
+    pinyin: zhǎo dào
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 了
+    pinyin: le
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Have you found a good job?
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 快
+    pinyin: kuài
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 找到
+    pinyin: zhǎo dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 丢失
+    pinyin: diū shī
+  - chinese: 的
+    pinyin: de
+  - chinese: 钱包
+    pinyin: qián bāo
+  - chinese: 。
+    pinyin: ''
+  english: She quickly found the lost wallet.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 找到
+    pinyin: zhǎo dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 解决
+    pinyin: jiě jué
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 的
+    pinyin: de
+  - chinese: 方法
+    pinyin: fāng fǎ
+  - chinese: 。
+    pinyin: ''
+  english: They found a way to solve the problem.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 找到
+    pinyin: zhǎo dào
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 餐厅
+    pinyin: cān tīng
+  - chinese: 的
+    pinyin: de
+  - chinese: ？
+    pinyin: ''
+  english: How did you find this restaurant?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 网上
+    pinyin: wǎng shàng
+  - chinese: 找到
+    pinyin: zhǎo dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 便宜
+    pinyin: pián yi
+  - chinese: 的
+    pinyin: de
+  - chinese: 机票
+    pinyin: jī piào
+  - chinese: 。
+    pinyin: ''
+  english: I found cheap plane tickets online.
+
+- segments:
+  - chinese: 鸟
+    pinyin: niǎo
+  - chinese: 在
+    pinyin: zài
+  - chinese: 天空
+    pinyin: tiān kōng
+  - chinese: 中
+    pinyin: zhōng
+  - chinese: 飞
+    pinyin: fēi
+  - chinese: 。
+    pinyin: ''
+  english: The bird flies in the sky.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 只
+    pinyin: zhǐ
+  - chinese: 风筝
+    pinyin: fēng zheng
+  - chinese: 飞
+    pinyin: fēi
+  - chinese: 得
+    pinyin: de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 高
+    pinyin: gāo
+  - chinese: 。
+    pinyin: ''
+  english: This kite is flying very high.
+
+- segments:
+  - chinese: 狗
+    pinyin: gǒu
+  - chinese: 和
+    pinyin: hé
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 不
+    pinyin: bù
+  - chinese: 会
+    pinyin: huì
+  - chinese: 飞
+    pinyin: fēi
+  - chinese: 。
+    pinyin: ''
+  english: Dogs and cats can't fly.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 的
+    pinyin: de
+  - chinese: 话
+    pinyin: huà
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 好听
+    pinyin: hǎo tīng
+  - chinese: ！
+    pinyin: ''
+  english: What you said sounds so nice!
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 弹琴
+    pinyin: tán qín
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好听
+    pinyin: hǎo tīng
+  - chinese: 。
+    pinyin: ''
+  english: Your piano playing sounds nice.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 唱歌
+    pinyin: chàng gē
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好听
+    pinyin: hǎo tīng
+  - chinese: 。
+    pinyin: ''
+  english: You have a nice singing voice.
+
+- segments:
+  - chinese: 后天
+    pinyin: hòu tiān
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 姐姐
+    pinyin: jiě jie
+  - chinese: 的
+    pinyin: de
+  - chinese: 生日
+    pinyin: shēng rì
+  - chinese: 。
+    pinyin: ''
+  english: The day after tomorrow is my sister's birthday.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 事情
+    pinyin: shì qing
+  - chinese: 不
+    pinyin: bù
+  - chinese: 能
+    pinyin: néng
+  - chinese: 推迟
+    pinyin: tuī chí
+  - chinese: 到
+    pinyin: dào
+  - chinese: 后天
+    pinyin: hòu tiān
+  - chinese: 。
+    pinyin: ''
+  english: This matter cannot be postponed until the day after tomorrow.
+
+- segments:
+  - chinese: 后天
+    pinyin: hòu tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 见面
+    pinyin: jiàn miàn
+  - chinese: 。
+    pinyin: ''
+  english: I'm available the day after tomorrow; we can meet up.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 后天
+    pinyin: hòu tiān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 计划
+    pinyin: jì huà
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you have any plans for the day after tomorrow?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 后天
+    pinyin: hòu tiān
+  - chinese: 会
+    pinyin: huì
+  - chinese: 去
+    pinyin: qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 医生
+    pinyin: yī shēng
+  - chinese: 。
+    pinyin: ''
+  english: I will go to see a doctor the day after tomorrow.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 进去
+    pinyin: jìn qù
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: You can go in now.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 敢
+    pinyin: gǎn
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 人
+    pinyin: rén
+  - chinese: 进去
+    pinyin: jìn qù
+  - chinese: 。
+    pinyin: ''
+  english: I'm afraid to go in alone.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 不
+    pinyin: bù
+  - chinese: 进去
+    pinyin: jìn qù
+  - chinese: 呢
+    pinyin: ne
+  - chinese: ？
+    pinyin: ''
+  english: Why don't you go in?
+
+- segments:
+  - chinese: 进去
+    pinyin: jìn qù
+  - chinese: 前
+    pinyin: qián
+  - chinese: 记得
+    pinyin: jì de
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 鞋子
+    pinyin: xié zi
+  - chinese: 脱
+    pinyin: tuō
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: Remember to take your shoes off before going in.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 进去
+    pinyin: jìn qù
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 分钟
+    pinyin: fēn zhōng
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 出来
+    pinyin: chū lái
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: You went in for just five minutes and then came out.
+
+- segments:
+  - chinese: 别
+    pinyin: bié
+  - chinese: 太
+    pinyin: tài
+  - chinese: 认真
+    pinyin: rèn zhēn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 只是
+    pinyin: zhǐ shì
+  - chinese: 在
+    pinyin: zài
+  - chinese: 开玩笑
+    pinyin: kāi wán xiào
+  - chinese: 。
+    pinyin: ''
+  english: Don't take it too seriously, I'm just joking.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 能
+    pinyin: néng
+  - chinese: 一直
+    pinyin: yī zhí
+  - chinese: 对
+    pinyin: duì
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 老板
+    pinyin: lǎo bǎn
+  - chinese: 开玩笑
+    pinyin: kāi wán xiào
+  - chinese: 。
+    pinyin: ''
+  english: You can't keep joking with your boss.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 俩
+    pinyin: liǎ
+  - chinese: 一直
+    pinyin: yī zhí
+  - chinese: 开
+    pinyin: kāi
+  - chinese: 对方
+    pinyin: duì fāng
+  - chinese: 的
+    pinyin: de
+  - chinese: 玩笑
+    pinyin: wán xiào
+  - chinese: 。
+    pinyin: ''
+  english: They are always joking with each other.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 别
+    pinyin: bié
+  - chinese: 开玩笑
+    pinyin: kāi wán xiào
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 现在
+    pinyin: xiàn zài
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 忙
+    pinyin: máng
+  - chinese: 。
+    pinyin: ''
+  english: Stop joking, I'm very busy now.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 看病
+    pinyin: kàn bìng
+  - chinese: 。
+    pinyin: ''
+  english: I'm going to see a doctor tomorrow.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 不
+    pinyin: bù
+  - chinese: 去
+    pinyin: qù
+  - chinese: 看病
+    pinyin: kàn bìng
+  - chinese: 呢
+    pinyin: ne
+  - chinese: ？
+    pinyin: ''
+  english: Why don't you go see a doctor?
+
+- segments:
+  - chinese: 看病
+    pinyin: kàn bìng
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 记得
+    pinyin: jì de
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 症状
+    pinyin: zhèng zhuàng
+  - chinese: 告诉
+    pinyin: gào su
+  - chinese: 医生
+    pinyin: yī shēng
+  - chinese: 。
+    pinyin: ''
+  english: When you see a doctor, remember to tell the symptoms to the doctor.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: 看病
+    pinyin: kàn bìng
+  - chinese: ？
+    pinyin: ''
+  english: Where do you go to see a doctor?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 不
+    pinyin: bù
+  - chinese: 早点
+    pinyin: zǎo diǎn
+  - chinese: 看病
+    pinyin: kàn bìng
+  - chinese: ？
+    pinyin: ''
+  english: Why didn't you see a doctor earlier?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 去
+    pinyin: qù
+  - chinese: 医院
+    pinyin: yī yuàn
+  - chinese: 看病
+    pinyin: kàn bìng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不
+    pinyin: bù
+  - chinese: 要
+    pinyin: yào
+  - chinese: 拖延
+    pinyin: tuō yán
+  - chinese: 。
+    pinyin: ''
+  english: You should go to the hospital to see a doctor; don't delay.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 读
+    pinyin: dú
+  - chinese: 了
+    pinyin: le
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 的
+    pinyin: de
+  - chinese: 课文
+    pinyin: kè wén
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Have you read today's lesson?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 篇
+    pinyin: piān
+  - chinese: 课文
+    pinyin: kè wén
+  - chinese: 的
+    pinyin: de
+  - chinese: 意思
+    pinyin: yì si
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you understand the meaning of this lesson?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 解释
+    pinyin: jiě shì
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 篇
+    pinyin: piān
+  - chinese: 课文
+    pinyin: kè wén
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you help me understand this lesson?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 复习
+    pinyin: fù xí
+  - chinese: 课文
+    pinyin: kè wén
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you help me review the lesson?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 读
+    pinyin: dú
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 篇
+    pinyin: piān
+  - chinese: 课文
+    pinyin: kè wén
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you help me read this lesson?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 分析
+    pinyin: fēn xī
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 篇
+    pinyin: piān
+  - chinese: 课文
+    pinyin: kè wén
+  - chinese: 的
+    pinyin: de
+  - chinese: 主要
+    pinyin: zhǔ yào
+  - chinese: 意思
+    pinyin: yì si
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you help me analyze the main idea of this lesson?
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 老人
+    pinyin: lǎo rén
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 帮助
+    pinyin: bāng zhù
+  - chinese: 。
+    pinyin: ''
+  english: That elderly person needs help.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 尊重
+    pinyin: zūn zhòng
+  - chinese: 老人
+    pinyin: lǎo rén
+  - chinese: 。
+    pinyin: ''
+  english: You should respect the elderly.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 老人
+    pinyin: lǎo rén
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 爷爷
+    pinyin: yé ye
+  - chinese: 。
+    pinyin: ''
+  english: That elderly man is my grandfather.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 照顾
+    pinyin: zhào gu
+  - chinese: 一下
+    pinyin: yī xià
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 老人
+    pinyin: lǎo rén
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you help me take care of that elderly person?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 让位
+    pinyin: ràng wèi
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 老人
+    pinyin: lǎo rén
+  - chinese: 。
+    pinyin: ''
+  english: You should give your seat to the elderly.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 老人
+    pinyin: lǎo rén
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 邻居
+    pinyin: lín jū
+  - chinese: 。
+    pinyin: ''
+  english: That elderly person is my neighbor.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 终于
+    pinyin: zhōng yú
+  - chinese: 来到
+    pinyin: lái dào
+  - chinese: 美国
+    pinyin: Měi guó
+  - chinese: 。
+    pinyin: ''
+  english: I finally arrived in the United States.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 会
+    pinyin: huì
+  - chinese: 来到
+    pinyin: lái dào
+  - chinese: 这里
+    pinyin: zhè lǐ
+  - chinese: 。
+    pinyin: ''
+  english: They will arrive here tomorrow.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 来到
+    pinyin: lái dào
+  - chinese: 中国
+    pinyin: Zhōng guó
+  - chinese: ？
+    pinyin: ''
+  english: When did you arrive in China?
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 今年
+    pinyin: jīn nián
+  - chinese: 夏天
+    pinyin: xià tiān
+  - chinese: 会
+    pinyin: huì
+  - chinese: 来到
+    pinyin: lái dào
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 的
+    pinyin: de
+  - chinese: 城市
+    pinyin: chéng shì
+  - chinese: 。
+    pinyin: ''
+  english: They will come to our city this summer.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 来到
+    pinyin: lái dào
+  - chinese: 这里
+    pinyin: zhè lǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: ？
+    pinyin: ''
+  english: How did you get here?
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 今晚
+    pinyin: jīn wǎn
+  - chinese: 会
+    pinyin: huì
+  - chinese: 来到
+    pinyin: lái dào
+  - chinese: 派对
+    pinyin: pài duì
+  - chinese: 。
+    pinyin: ''
+  english: They will arrive at the party tonight.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 面包
+    pinyin: miàn bāo
+  - chinese: 。
+    pinyin: ''
+  english: I like to eat bread.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一
+    pinyin: yī
+  - chinese: 片
+    pinyin: piàn
+  - chinese: 面包
+    pinyin: miàn bāo
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you give me a slice of bread?
+
+- segments:
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 面包
+    pinyin: miàn bāo
+  - chinese: 篮子
+    pinyin: lán zi
+  - chinese: 。
+    pinyin: ''
+  english: There is a bread basket on the table.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 教
+    pinyin: jiāo
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 面包
+    pinyin: miàn bāo
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you teach me how to make bread?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 吐司
+    pinyin: tǔ sī
+  - chinese: 面包
+    pinyin: miàn bāo
+  - chinese: 。
+    pinyin: ''
+  english: I like to eat toast bread.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 过
+    pinyin: guò
+  - chinese: 法国
+    pinyin: Fǎ guó
+  - chinese: 面包
+    pinyin: miàn bāo
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Have you ever eaten French bread?
+
+- segments:
+  - chinese: 明年
+    pinyin: míng nián
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 中国
+    pinyin: Zhōng guó
+  - chinese: 。
+    pinyin: ''
+  english: I will go to China next year.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 明年
+    pinyin: míng nián
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 计划
+    pinyin: jì huà
+  - chinese: ？
+    pinyin: ''
+  english: What are your plans for next year?
+
+- segments:
+  - chinese: 明年
+    pinyin: míng nián
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打算
+    pinyin: dǎ suàn
+  - chinese: 去
+    pinyin: qù
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 。
+    pinyin: ''
+  english: I plan to go on a trip next year.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 明年
+    pinyin: míng nián
+  - chinese: 会
+    pinyin: huì
+  - chinese: 毕业
+    pinyin: bì yè
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Will you graduate next year?
+
+- segments:
+  - chinese: 明年
+    pinyin: míng nián
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 开始
+    pinyin: kāi shǐ
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 大学
+    pinyin: dà xué
+  - chinese: 。
+    pinyin: ''
+  english: I will start college next year.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 明年
+    pinyin: míng nián
+  - chinese: 会
+    pinyin: huì
+  - chinese: 搬家
+    pinyin: bān jiā
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Are you going to move next year?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 家人
+    pinyin: jiā rén
+  - chinese: 住
+    pinyin: zhù
+  - chinese: 在
+    pinyin: zài
+  - chinese: 那边
+    pinyin: nà bian
+  - chinese: 。
+    pinyin: ''
+  english: My family lives over there.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 不能
+    pinyin: bù néng
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 那边
+    pinyin: nà bian
+  - chinese: ？
+    pinyin: ''
+  english: Can you sit over there?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 住
+    pinyin: zhù
+  - chinese: 在
+    pinyin: zài
+  - chinese: 那边
+    pinyin: nà bian
+  - chinese: 。
+    pinyin: ''
+  english: My friend lives over there.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 那边
+    pinyin: nà bian
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 杯子
+    pinyin: bēi zi
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you pass me that cup over there?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 那边
+    pinyin: nà bian
+  - chinese: 等
+    pinyin: děng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you wait for me over there?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 告诉
+    pinyin: gào sù
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 那边
+    pinyin: nà bian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 店
+    pinyin: diàn
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you tell me what stores are over there?
+
+- segments:
+  - chinese: 那里
+    pinyin: nà li
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 不错
+    pinyin: bù cuò
+  - chinese: 的
+    pinyin: de
+  - chinese: 餐厅
+    pinyin: cān tīng
+  - chinese: 。
+    pinyin: ''
+  english: There is a pretty good restaurant over there.
+
+- segments:
+  - chinese: 那里
+    pinyin: nà li
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 。
+    pinyin: ''
+  english: There is a park over there.
+
+- segments:
+  - chinese: 那里
+    pinyin: nà li
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 医院
+    pinyin: yī yuàn
+  - chinese: 。
+    pinyin: ''
+  english: There is a hospital over there.
+
+- segments:
+  - chinese: 那里
+    pinyin: nà li
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 银行
+    pinyin: yín háng
+  - chinese: 。
+    pinyin: ''
+  english: There is a bank over there.
+
+- segments:
+  - chinese: 那里
+    pinyin: nà li
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 超市
+    pinyin: chāo shì
+  - chinese: 。
+    pinyin: ''
+  english: There is a supermarket over there.
+
+- segments:
+  - chinese: 那里
+    pinyin: nà li
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 邮局
+    pinyin: yóu jú
+  - chinese: 。
+    pinyin: ''
+  english: There is a post office over there.
+
+- segments:
+  - chinese: 那里
+    pinyin: nà li
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 警察
+    pinyin: jǐng chá
+  - chinese: 局
+    pinyin: jú
+  - chinese: 。
+    pinyin: ''
+  english: There is a police station over there.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 那儿
+    pinyin: nà r
+  - chinese: 。
+    pinyin: ''
+  english: I'm going there tomorrow.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 住
+    pinyin: zhù
+  - chinese: 在
+    pinyin: zài
+  - chinese: 那儿
+    pinyin: nà r
+  - chinese: 。
+    pinyin: ''
+  english: My friend lives over there.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 那儿
+    pinyin: nà r
+  - chinese: 等
+    pinyin: děng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you wait for me over there?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 那儿
+    pinyin: nà r
+  - chinese: 的
+    pinyin: de
+  - chinese: 地址
+    pinyin: dì zhǐ
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you give me the address over there?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 告诉
+    pinyin: gào sù
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 那儿
+    pinyin: nà r
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 去
+    pinyin: qù
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you tell me how to get there?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 带
+    pinyin: dài
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 那儿
+    pinyin: nà r
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you take me there?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 奶奶
+    pinyin: nǎi nai
+  - chinese: 今年
+    pinyin: jīn nián
+  - chinese: 八十
+    pinyin: bā shí
+  - chinese: 岁
+    pinyin: suì
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: My grandmother is eighty years old this year.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 奶奶
+    pinyin: nǎi nai
+  - chinese: 。
+    pinyin: ''
+  english: I'm going to visit my grandmother tomorrow.
+
+- segments:
+  - chinese: 奶奶
+    pinyin: nǎi nai
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 织
+    pinyin: zhī
+  - chinese: 了
+    pinyin: le
+  - chinese: 毛衣
+    pinyin: máo yī
+  - chinese: 。
+    pinyin: ''
+  english: My grandmother knitted a sweater for me.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 爱
+    pinyin: ài
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 奶奶
+    pinyin: nǎi nai
+  - chinese: 。
+    pinyin: ''
+  english: I love my grandmother very much.
+
+- segments:
+  - chinese: 奶奶
+    pinyin: nǎi nai
+  - chinese: 总是
+    pinyin: zǒng shì
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 零食
+    pinyin: líng shí
+  - chinese: 。
+    pinyin: ''
+  english: My grandmother always gives me a lot of snacks.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 奶奶
+    pinyin: nǎi nai
+  - chinese: 做饭
+    pinyin: zuò fàn
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 得
+    pinyin: de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好吃
+    pinyin: hǎo chī
+  - chinese: 。
+    pinyin: ''
+  english: My grandmother cooks delicious meals.
+
+- segments:
+  - chinese: 天
+    pinyin: tiān
+  - chinese: 渐渐
+    pinyin: jiàn jiàn
+  - chinese: 亮
+    pinyin: liàng
+  - chinese: 起来
+    pinyin: qi lai
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: The sky is gradually brightening.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 生气
+    pinyin: shēng qì
+  - chinese: 起来
+    pinyin: qi lai
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 可怕
+    pinyin: kě pà
+  - chinese: 。
+    pinyin: ''
+  english: She's scary when she gets angry.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 唱
+    pinyin: chàng
+  - chinese: 起来
+    pinyin: qi lai
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 首
+    pinyin: shǒu
+  - chinese: 歌曲
+    pinyin: gē qǔ
+  - chinese: 。
+    pinyin: ''
+  english: They sing this song.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 聊
+    pinyin: liáo
+  - chinese: 起来
+    pinyin: qi lai
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 话题
+    pinyin: huà tí
+  - chinese: 。
+    pinyin: ''
+  english: They chat about this topic.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 笑
+    pinyin: xiào
+  - chinese: 起来
+    pinyin: qi lai
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 甜
+    pinyin: tián
+  - chinese: 。
+    pinyin: ''
+  english: Her laughter is very sweet.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 起来
+    pinyin: qi lai
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 步
+    pinyin: bù
+  - chinese: 舞
+    pinyin: wǔ
+  - chinese: 。
+    pinyin: ''
+  english: They perform this dance.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 请假
+    pinyin: qǐng jià
+  - chinese: 去
+    pinyin: qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 医生
+    pinyin: yī shēng
+  - chinese: 。
+    pinyin: ''
+  english: I need to take a leave to see a doctor.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 请假
+    pinyin: qǐng jià
+  - chinese: 去
+    pinyin: qù
+  - chinese: 照顾
+    pinyin: zhào gu
+  - chinese: 生病
+    pinyin: shēng bìng
+  - chinese: 的
+    pinyin: de
+  - chinese: 孩子
+    pinyin: hái zi
+  - chinese: 。
+    pinyin: ''
+  english: She took a leave to take care of her sick child.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 向
+    pinyin: xiàng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 老板
+    pinyin: lǎo bǎn
+  - chinese: 请假
+    pinyin: qǐng jià
+  - chinese: 参加
+    pinyin: cān jiā
+  - chinese: 婚
+    pinyin: hūn
+  - chinese: 礼
+    pinyin: lǐ
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you take a leave from your boss to attend the wedding?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 认识
+    pinyin: rèn shi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 有趣
+    pinyin: yǒu qù
+  - chinese: 的
+    pinyin: de
+  - chinese: 人
+    pinyin: rén
+  - chinese: 。
+    pinyin: ''
+  english: I know a lot of interesting people.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 认识
+    pinyin: rèn shi
+  - chinese: 那
+    pinyin: nà
+  - chinese: 位
+    pinyin: wèi
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you know the new teacher?
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 是
+    pinyin: shì
+  - chinese: 在
+    pinyin: zài
+  - chinese: 大学
+    pinyin: dà xué
+  - chinese: 认识
+    pinyin: rèn shi
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: They met each other in college.
+
+- segments:
+  - chinese: 认识
+    pinyin: rèn shi
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 是
+    pinyin: shì
+  - chinese: 太
+    pinyin: tài
+  - chinese: 高兴
+    pinyin: gāo xìng
+  - chinese: 了
+    pinyin: le
+  - chinese: ！
+    pinyin: ''
+  english: I'm so glad to have met you!
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 聚会
+    pinyin: jù huì
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 认识
+    pinyin: rèn shi
+  - chinese: 了
+    pinyin: le
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 。
+    pinyin: ''
+  english: We met a lot of new friends at the party.
+
+- segments:
+  - chinese: 考试
+    pinyin: kǎo shì
+  - chinese: 日期
+    pinyin: rì qī
+  - chinese: 快
+    pinyin: kuài
+  - chinese: 到
+    pinyin: dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: The exam date is approaching.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 的
+    pinyin: de
+  - chinese: 婚
+    pinyin: hūn
+  - chinese: 礼
+    pinyin: lǐ
+  - chinese: 日期
+    pinyin: rì qī
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you know the date of their wedding?
+
+- segments:
+  - chinese: 会议
+    pinyin: huì yì
+  - chinese: 日期
+    pinyin: rì qī
+  - chinese: 推迟
+    pinyin: tuī chí
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: The meeting date has been postponed.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 项目
+    pinyin: xiàng mù
+  - chinese: 的
+    pinyin: de
+  - chinese: 截止
+    pinyin: jié zhǐ
+  - chinese: 日期
+    pinyin: rì qī
+  - chinese: 是
+    pinyin: shì
+  - chinese: 下
+    pinyin: xià
+  - chinese: 周一
+    pinyin: Zhōu yī
+  - chinese: 。
+    pinyin: ''
+  english: The deadline for this project is next Monday.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 告诉
+    pinyin: gào sù
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 出生
+    pinyin: chū shēng
+  - chinese: 日期
+    pinyin: rì qī
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you tell me your date of birth?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 在
+    pinyin: zài
+  - chinese: 上车
+    pinyin: shàng chē
+  - chinese: 前
+    pinyin: qián
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 票
+    pinyin: piào
+  - chinese: 。
+    pinyin: ''
+  english: You need to buy a ticket before boarding.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 绿
+    pinyin: lǜ
+  - chinese: 灯
+    pinyin: dēng
+  - chinese: 亮
+    pinyin: liàng
+  - chinese: 时
+    pinyin: shí
+  - chinese: 上车
+    pinyin: shàng chē
+  - chinese: 。
+    pinyin: ''
+  english: Please board when the green light is on.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 上车
+    pinyin: shàng chē
+  - chinese: 的
+    pinyin: de
+  - chinese: ？
+    pinyin: ''
+  english: How did you get on?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 行李
+    pinyin: xíng li
+  - chinese: 箱
+    pinyin: xiāng
+  - chinese: 抬
+    pinyin: tái
+  - chinese: 上车
+    pinyin: shàng chē
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you help me lift the suitcase onto the car?
+
+- segments:
+  - chinese: 最后
+    pinyin: zuì hòu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 班车
+    pinyin: bān chē
+  - chinese: 是
+    pinyin: shì
+  - chinese: 晚上
+    pinyin: wǎn shang
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 点钟
+    pinyin: diǎn zhōng
+  - chinese: 上车
+    pinyin: shàng chē
+  - chinese: 。
+    pinyin: ''
+  english: The last bus departs at 9:00 p.m. sharp.
+
+- segments:
+  - chinese: 在
+    pinyin: zài
+  - chinese: 上车
+    pinyin: shàng chē
+  - chinese: 前
+    pinyin: qián
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 必须
+    pinyin: bì xū
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 手机
+    pinyin: shǒu jī
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 到
+    pinyin: dào
+  - chinese: 口袋
+    pinyin: kǒu dài
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 。
+    pinyin: ''
+  english: Before boarding, you must put your cell phone in your pocket.
+
+- segments:
+  - chinese: 上次
+    pinyin: shàng cì
+  - chinese: 考试
+    pinyin: kǎo shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 得了
+    pinyin: dé le
+  - chinese: 满分
+    pinyin: mǎn fēn
+  - chinese: 。
+    pinyin: ''
+  english: I got a perfect score on the last exam.
+
+- segments:
+  - chinese: 上次
+    pinyin: shàng cì
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 中国
+    pinyin: Zhōng guó
+  - chinese: 是
+    pinyin: shì
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ？
+    pinyin: ''
+  english: When was the last time you went to China?
+
+- segments:
+  - chinese: 上次
+    pinyin: shàng cì
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 去
+    pinyin: qù
+  - chinese: 的
+    pinyin: de
+  - chinese: 那
+    pinyin: nà
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 餐厅
+    pinyin: cān tīng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好吃
+    pinyin: hǎo chī
+  - chinese: 。
+    pinyin: ''
+  english: The restaurant we went to last time was very delicious.
+
+- segments:
+  - chinese: 上次
+    pinyin: shàng cì
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 借
+    pinyin: jiè
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 书
+    pinyin: shū
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: ？
+    pinyin: ''
+  english: Where is the book you borrowed from me last time?
+
+- segments:
+  - chinese: 上次
+    pinyin: shàng cì
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 见面
+    pinyin: jiàn miàn
+  - chinese: 是
+    pinyin: shì
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 个
+    pinyin: gè
+  - chinese: 月
+    pinyin: yuè
+  - chinese: 前
+    pinyin: qián
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: It's been several months since we last met.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 上次
+    pinyin: shàng cì
+  - chinese: 去
+    pinyin: qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 演唱
+    pinyin: yǎn chàng
+  - chinese: 会
+    pinyin: huì
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 遇到
+    pinyin: yù dào
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 交通
+    pinyin: jiāo tōng
+  - chinese: 堵塞
+    pinyin: dǔ sè
+  - chinese: 。
+    pinyin: ''
+  english: The last time I went to a concert, I ran into a lot of traffic jams.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 早上
+    pinyin: zǎo shang
+  - chinese: 起来
+    pinyin: qǐ lai
+  - chinese: 先
+    pinyin: xiān
+  - chinese: 上网
+    pinyin: shàng wǎng
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 新闻
+    pinyin: xīn wén
+  - chinese: 。
+    pinyin: ''
+  english: Every morning, I go online to read the news first thing.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 上网
+    pinyin: shàng wǎng
+  - chinese: 找
+    pinyin: zhǎo
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 了
+    pinyin: le
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Have you been job hunting online?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 通过
+    pinyin: tōng guò
+  - chinese: 上网
+    pinyin: shàng wǎng
+  - chinese: 来
+    pinyin: lái
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 的
+    pinyin: de
+  - chinese: 语言
+    pinyin: yǔ yán
+  - chinese: 。
+    pinyin: ''
+  english: You can learn new languages by going online.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 通过
+    pinyin: tōng guò
+  - chinese: 上网
+    pinyin: shàng wǎng
+  - chinese: 来
+    pinyin: lái
+  - chinese: 预订
+    pinyin: yù dìng
+  - chinese: 机票
+    pinyin: jī piào
+  - chinese: 。
+    pinyin: ''
+  english: You can book flight tickets online.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 通过
+    pinyin: tōng guò
+  - chinese: 上网
+    pinyin: shàng wǎng
+  - chinese: 来
+    pinyin: lái
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 聊天
+    pinyin: liáo tiān
+  - chinese: 。
+    pinyin: ''
+  english: You can chat with friends online.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 上网
+    pinyin: shàng wǎng
+  - chinese: 研究
+    pinyin: yán jiū
+  - chinese: 了
+    pinyin: le
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 多
+    pinyin: duō
+  - chinese: 久
+    pinyin: jiǔ
+  - chinese: 了
+    pinyin: le
+  - chinese: ？
+    pinyin: ''
+  english: How long have you been researching this issue online?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 早上
+    pinyin: zǎo shang
+  - chinese: 八
+    pinyin: bā
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 上学
+    pinyin: shàng xué
+  - chinese: 。
+    pinyin: ''
+  english: I go to school at 8 a.m. every morning.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 上学
+    pinyin: shàng xué
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 经常
+    pinyin: jīng cháng
+  - chinese: 迟到
+    pinyin: chí dào
+  - chinese: 。
+    pinyin: ''
+  english: When I was in school, I often arrived late.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 上学
+    pinyin: shàng xué
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 多
+    pinyin: duō
+  - chinese: 长
+    pinyin: cháng
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: ？
+    pinyin: ''
+  english: How long does it take for you to get to school?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 上学
+    pinyin: shàng xué
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 严格
+    pinyin: yán gé
+  - chinese: 。
+    pinyin: ''
+  english: When I was in school, my teacher was very strict.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 上学
+    pinyin: shàng xué
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 的
+    pinyin: de
+  - chinese: 科目
+    pinyin: kē mù
+  - chinese: 是
+    pinyin: shì
+  - chinese: 数学
+    pinyin: shù xué
+  - chinese: 。
+    pinyin: ''
+  english: When I was in school, my favorite subject was math.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 上学
+    pinyin: shàng xué
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有没有
+    pinyin: yǒu méi yǒu
+  - chinese: 参加
+    pinyin: cān jiā
+  - chinese: 过
+    pinyin: guò
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 的
+    pinyin: de
+  - chinese: 乐队
+    pinyin: yuè duì
+  - chinese: ？
+    pinyin: ''
+  english: When you were in school, did you ever join the school band?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 上学
+    pinyin: shàng xué
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有没有
+    pinyin: yǒu méi yǒu
+  - chinese: 遇到
+    pinyin: yù dào
+  - chinese: 过
+    pinyin: guò
+  - chinese: 困难
+    pinyin: kùn nan
+  - chinese: ？
+    pinyin: ''
+  english: During your time in school, did you ever face any challenges?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 身上
+    pinyin: shēn shang
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 是
+    pinyin: shì
+  - chinese: 泥
+    pinyin: ní
+  - chinese: 。
+    pinyin: ''
+  english: His body is covered in mud.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 身上
+    pinyin: shēn shang
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 钱
+    pinyin: qián
+  - chinese: 。
+    pinyin: ''
+  english: I don't have any money on me.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 身上
+    pinyin: shēn shang
+  - chinese: 有没有
+    pinyin: yǒu méi yǒu
+  - chinese: 看到
+    pinyin: kàn dào
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 钥匙
+    pinyin: yào shi
+  - chinese: ？
+    pinyin: ''
+  english: Have you seen my keys on you?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 身上
+    pinyin: shēn shang
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 道
+    pinyin: dào
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 长
+    pinyin: cháng
+  - chinese: 的
+    pinyin: de
+  - chinese: 疤
+    pinyin: bā
+  - chinese: 痕
+    pinyin: hén
+  - chinese: 。
+    pinyin: ''
+  english: He has a long scar on his body.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 身上
+    pinyin: shēn shang
+  - chinese: 穿
+    pinyin: chuān
+  - chinese: 的
+    pinyin: de
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 。
+    pinyin: ''
+  english: The dress she's wearing is very beautiful.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 钱
+    pinyin: qián
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 到
+    pinyin: dào
+  - chinese: 身上
+    pinyin: shēn shang
+  - chinese: 的
+    pinyin: de
+  - chinese: 口袋
+    pinyin: kǒu dài
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 。
+    pinyin: ''
+  english: You can put the money in your pocket.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 身上
+    pinyin: shēn shang
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 股
+    pinyin: gǔ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 浓
+    pinyin: nóng
+  - chinese: 的
+    pinyin: de
+  - chinese: 酒味
+    pinyin: jiǔ wèi
+  - chinese: 。
+    pinyin: ''
+  english: He has a strong smell of alcohol on his body.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 书包
+    pinyin: shū bāo
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: 了
+    pinyin: le
+  - chinese: ？
+    pinyin: ''
+  english: Where did you put your backpack?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 书包
+    pinyin: shū bāo
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 重
+    pinyin: zhòng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 因为
+    pinyin: yīn wèi
+  - chinese: 里面
+    pinyin: lǐ miàn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: My backpack is very heavy because there are a lot of books inside.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 书
+    pinyin: shū
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 进
+    pinyin: jìn
+  - chinese: 书包
+    pinyin: shū bāo
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 。
+    pinyin: ''
+  english: You can put the books into your backpack.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 书包
+    pinyin: shū bāo
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 零食
+    pinyin: líng shí
+  - chinese: 。
+    pinyin: ''
+  english: There are a lot of snacks in his backpack.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 拿
+    pinyin: ná
+  - chinese: 一下
+    pinyin: yī xià
+  - chinese: 书包
+    pinyin: shū bāo
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you help me carry my backpack for a moment?
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 书包
+    pinyin: shū bāo
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: ，
+    pinyin: ''
+  - chinese: 是
+    pinyin: shì
+  - chinese: 粉红色
+    pinyin: fěn hóng sè
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: Her backpack is very pretty and it's pink.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 上学
+    pinyin: shàng xué
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 总是
+    pinyin: zǒng shì
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 书包
+    pinyin: shū bāo
+  - chinese: 弄
+    pinyin: nòng
+  - chinese: 丢
+    pinyin: diū
+  - chinese: 。
+    pinyin: ''
+  english: When I was in school, I would always lose my backpack.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 的
+    pinyin: de
+  - chinese: 书店
+    pinyin: shū diàn
+  - chinese: 是
+    pinyin: shì
+  - chinese: 哪
+    pinyin: nǎ
+  - chinese: 一
+    pinyin: yī
+  - chinese: 家
+    pinyin: jiā
+  - chinese: ？
+    pinyin: ''
+  english: Which bookstore do you like the most?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 经常
+    pinyin: jīng cháng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 书店
+    pinyin: shū diàn
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 看书
+    pinyin: kàn shū
+  - chinese: 。
+    pinyin: ''
+  english: I often read books at the bookstore.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 书店
+    pinyin: shū diàn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 各种各样
+    pinyin: gè zhǒng gè yàng
+  - chinese: 的
+    pinyin: de
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: This bookstore has all sorts of books.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 告诉
+    pinyin: gào sù
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 最近
+    pinyin: zuì jìn
+  - chinese: 的
+    pinyin: de
+  - chinese: 书店
+    pinyin: shū diàn
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you tell me where the nearest bookstore is?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 书店
+    pinyin: shū diàn
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 找到
+    pinyin: zhǎo dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 的
+    pinyin: de
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I found the book I like at the bookstore.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 书店
+    pinyin: shū diàn
+  - chinese: 提供
+    pinyin: tí gōng
+  - chinese: 各种各样
+    pinyin: gè zhǒng gè yàng
+  - chinese: 的
+    pinyin: de
+  - chinese: 服务
+    pinyin: fú wù
+  - chinese: ，
+    pinyin: ''
+  - chinese: 包括
+    pinyin: bāo kuò
+  - chinese: 租
+    pinyin: zū
+  - chinese: 书
+    pinyin: shū
+  - chinese: 和
+    pinyin: hé
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: This bookstore offers a variety of services, including book rentals and purchases.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 网上
+    pinyin: wǎng shàng
+  - chinese: 或
+    pinyin: huò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 实
+    pinyin: shí
+  - chinese: 体
+    pinyin: tǐ
+  - chinese: 书店
+    pinyin: shū diàn
+  - chinese: 中
+    pinyin: zhōng
+  - chinese: 购买
+    pinyin: gòu mǎi
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: You can buy books online or from physical bookstores.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 机场
+    pinyin: jī chǎng
+  - chinese: 送
+    pinyin: sòng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 哥哥
+    pinyin: gē ge
+  - chinese: 。
+    pinyin: ''
+  english: I'm going to the airport tomorrow to see my brother off.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 送
+    pinyin: sòng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一
+    pinyin: yī
+  - chinese: 瓶
+    pinyin: píng
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you bring me a bottle of water?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 送
+    pinyin: sòng
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 束
+    pinyin: shù
+  - chinese: 花
+    pinyin: huā
+  - chinese: 。
+    pinyin: ''
+  english: My mom sent me a bouquet of flowers.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 送
+    pinyin: sòng
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 包裹
+    pinyin: bāo guǒ
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you help me deliver this package?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 送
+    pinyin: sòng
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 份
+    pinyin: fèn
+  - chinese: 礼物
+    pinyin: lǐ wù
+  - chinese: 。
+    pinyin: ''
+  english: I sent you a gift.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 送
+    pinyin: sòng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 火车站
+    pinyin: huǒ chē zhàn
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you take me to the train station?
+
+- segments:
+  - chinese: 快递
+    pinyin: kuài dì
+  - chinese: 小
+    pinyin: xiǎo
+  - chinese: 哥
+    pinyin: gē
+  - chinese: 送
+    pinyin: sòng
+  - chinese: 了
+    pinyin: le
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 包裹
+    pinyin: bāo guǒ
+  - chinese: 。
+    pinyin: ''
+  english: The delivery guy brought me a package.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 送
+    pinyin: sòng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 回家
+    pinyin: huí jiā
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you give me a ride home?
+
+- segments:
+  - chinese: 她们
+    pinyin: tā men
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 。
+    pinyin: ''
+  english: They are good friends.
+
+- segments:
+  - chinese: 她们
+    pinyin: tā men
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: They are going to watch a movie tomorrow.
+
+- segments:
+  - chinese: 她们
+    pinyin: tā men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 店
+    pinyin: diàn
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 聊天
+    pinyin: liáo tiān
+  - chinese: 。
+    pinyin: ''
+  english: They are chatting in the coffee shop.
+
+- segments:
+  - chinese: 她们
+    pinyin: tā men
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 是
+    pinyin: shì
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 。
+    pinyin: ''
+  english: They are both teachers.
+
+- segments:
+  - chinese: 她们
+    pinyin: tā men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: 见面
+    pinyin: jiàn miàn
+  - chinese: ？
+    pinyin: ''
+  english: Where are they meeting?
+
+- segments:
+  - chinese: 她们
+    pinyin: tā men
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 相同
+    pinyin: xiāng tóng
+  - chinese: 的
+    pinyin: de
+  - chinese: 爱好
+    pinyin: ài hào
+  - chinese: 。
+    pinyin: ''
+  english: They share the same hobbies.
+
+- segments:
+  - chinese: 她们
+    pinyin: tā men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 认识
+    pinyin: rèn shi
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: They met each other at school.
+
+- segments:
+  - chinese: 她们
+    pinyin: tā men
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 兄弟
+    pinyin: xiōng dì
+  - chinese: 。
+    pinyin: ''
+  english: They both have brothers.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 听见
+    pinyin: tīng jiàn
+  - chinese: 外面
+    pinyin: wài miàn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 声音
+    pinyin: shēng yīn
+  - chinese: 。
+    pinyin: ''
+  english: I hear a sound outside.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 听见
+    pinyin: tīng jiàn
+  - chinese: 他
+    pinyin: tā
+  - chinese: 说话
+    pinyin: shuō huà
+  - chinese: 了
+    pinyin: le
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Did you hear him talking?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 听见
+    pinyin: tīng jiàn
+  - chinese: 鸟
+    pinyin: niǎo
+  - chinese: 在
+    pinyin: zài
+  - chinese: 唱歌
+    pinyin: chàng gē
+  - chinese: 。
+    pinyin: ''
+  english: I hear birds singing.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 听见
+    pinyin: tīng jiàn
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 了
+    pinyin: le
+  - chinese: ？
+    pinyin: ''
+  english: What did you hear?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 听见
+    pinyin: tīng jiàn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 人
+    pinyin: rén
+  - chinese: 叫
+    pinyin: jiào
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 名字
+    pinyin: míng zi
+  - chinese: 。
+    pinyin: ''
+  english: I heard someone calling my name.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 听见
+    pinyin: tīng jiàn
+  - chinese: 隔壁
+    pinyin: gé bì
+  - chinese: 的
+    pinyin: de
+  - chinese: 狗
+    pinyin: gǒu
+  - chinese: 在
+    pinyin: zài
+  - chinese: 叫
+    pinyin: jiào
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you hear the dog barking next door?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 昨晚
+    pinyin: zuó wǎn
+  - chinese: 听见
+    pinyin: tīng jiàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 雷声
+    pinyin: léi shēng
+  - chinese: 。
+    pinyin: ''
+  english: I heard thunder last night.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 听见
+    pinyin: tīng jiàn
+  - chinese: 新闻
+    pinyin: xīn wén
+  - chinese: 了
+    pinyin: le
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Did you hear the news?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 听见
+    pinyin: tīng jiàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 水流
+    pinyin: shuǐ liú
+  - chinese: 声
+    pinyin: shēng
+  - chinese: 。
+    pinyin: ''
+  english: I heard the sound of flowing water.
+
+- segments:
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 让
+    pinyin: ràng
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 听写
+    pinyin: tīng xiě
+  - chinese: 练习
+    pinyin: liàn xí
+  - chinese: 。
+    pinyin: ''
+  english: The teacher asked us to do dictation practice.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 听写
+    pinyin: tīng xiě
+  - chinese: 练习
+    pinyin: liàn xí
+  - chinese: 来
+    pinyin: lái
+  - chinese: 提
+    pinyin: tí
+  - chinese: 高
+    pinyin: gāo
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 拼写
+    pinyin: pīn xiě
+  - chinese: 能力
+    pinyin: néng lì
+  - chinese: 。
+    pinyin: ''
+  english: You need to do dictation exercises to improve your spelling skills.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 听写
+    pinyin: tīng xiě
+  - chinese: 练习
+    pinyin: liàn xí
+  - chinese: 来
+    pinyin: lái
+  - chinese: 练习
+    pinyin: liàn xí
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 听力
+    pinyin: tīng lì
+  - chinese: 。
+    pinyin: ''
+  english: You can do dictation exercises to practice your listening skills.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 听写
+    pinyin: tīng xiě
+  - chinese: 练习
+    pinyin: liàn xí
+  - chinese: 来
+    pinyin: lái
+  - chinese: 提
+    pinyin: tí
+  - chinese: 高
+    pinyin: gāo
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 汉语
+    pinyin: Hàn yǔ
+  - chinese: 水平
+    pinyin: shuǐ píng
+  - chinese: 。
+    pinyin: ''
+  english: You can do dictation exercises to improve your Chinese language proficiency.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 听写
+    pinyin: tīng xiě
+  - chinese: 了
+    pinyin: le
+  - chinese: 多少
+    pinyin: duō shǎo
+  - chinese: 个
+    pinyin: gè
+  - chinese: 单词
+    pinyin: dān cí
+  - chinese: ？
+    pinyin: ''
+  english: How many words did you transcribe?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 听写
+    pinyin: tīng xiě
+  - chinese: 练习
+    pinyin: liàn xí
+  - chinese: 来
+    pinyin: lái
+  - chinese: 提
+    pinyin: tí
+  - chinese: 高
+    pinyin: gāo
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 写作
+    pinyin: xiě zuò
+  - chinese: 能力
+    pinyin: néng lì
+  - chinese: 。
+    pinyin: ''
+  english: You can do dictation exercises to improve your writing skills.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 听写
+    pinyin: tīng xiě
+  - chinese: 练习
+    pinyin: liàn xí
+  - chinese: 来
+    pinyin: lái
+  - chinese: 练习
+    pinyin: liàn xí
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 发音
+    pinyin: fā yīn
+  - chinese: 。
+    pinyin: ''
+  english: You can do dictation exercises to practice your pronunciation.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 听写
+    pinyin: tīng xiě
+  - chinese: 了
+    pinyin: le
+  - chinese: 十
+    pinyin: shí
+  - chinese: 个
+    pinyin: gè
+  - chinese: 句子
+    pinyin: jù zi
+  - chinese: 。
+    pinyin: ''
+  english: I transcribed ten sentences.
+
+- segments:
+  - chinese: 外边
+    pinyin: wài bian
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 拿
+    pinyin: ná
+  - chinese: 雨伞
+    pinyin: yǔ sǎn
+  - chinese: 。
+    pinyin: ''
+  english: It's raining outside, I need to get an umbrella.
+
+- segments:
+  - chinese: 外边
+    pinyin: wài bian
+  - chinese: 太
+    pinyin: tài
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 关
+    pinyin: guān
+  - chinese: 窗户
+    pinyin: chuāng hu
+  - chinese: 。
+    pinyin: ''
+  english: It's too cold outside, I'm going to close the window.
+
+- segments:
+  - chinese: 外边
+    pinyin: wài bian
+  - chinese: 太
+    pinyin: tài
+  - chinese: 热
+    pinyin: rè
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 开
+    pinyin: kāi
+  - chinese: 空调
+    pinyin: kōng tiáo
+  - chinese: 。
+    pinyin: ''
+  english: It's too hot outside, I need to turn on the air conditioning.
+
+- segments:
+  - chinese: 外边
+    pinyin: wài bian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 声音
+    pinyin: shēng yīn
+  - chinese: ？
+    pinyin: ''
+  english: What's that sound outside?
+
+- segments:
+  - chinese: 外边
+    pinyin: wài bian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 动静
+    pinyin: dòng jìng
+  - chinese: ？
+    pinyin: ''
+  english: What's going on outside?
+
+- segments:
+  - chinese: 外边
+    pinyin: wài bian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 。
+    pinyin: ''
+  english: There's a cat outside.
+
+- segments:
+  - chinese: 外边
+    pinyin: wài bian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 男人
+    pinyin: nán rén
+  - chinese: 。
+    pinyin: ''
+  english: There's a man outside.
+
+- segments:
+  - chinese: 外边
+    pinyin: wài bian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 女人
+    pinyin: nǚ rén
+  - chinese: 。
+    pinyin: ''
+  english: There's a woman outside.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 住
+    pinyin: zhù
+  - chinese: 在
+    pinyin: zài
+  - chinese: 外国
+    pinyin: wài guó
+  - chinese: 。
+    pinyin: ''
+  english: He lives in a foreign country.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 外国
+    pinyin: wài guó
+  - chinese: 的
+    pinyin: de
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What do you like about foreign countries?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 外国
+    pinyin: wài guó
+  - chinese: 上学
+    pinyin: shàng xué
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you want to study abroad?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 外国
+    pinyin: wài guó
+  - chinese: 学
+    pinyin: xué
+  - chinese: 到
+    pinyin: dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What did you learn while in a foreign country?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 外国
+    pinyin: wài guó
+  - chinese: 遇
+    pinyin: yù
+  - chinese: 到
+    pinyin: dào
+  - chinese: 过
+    pinyin: guò
+  - chinese: 困难
+    pinyin: kùn nan
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Have you faced any challenges while in a foreign country?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 外国
+    pinyin: wài guó
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: ？
+    pinyin: ''
+  english: Why do you want to work in a foreign country?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 外国
+    pinyin: wài guó
+  - chinese: 学
+    pinyin: xué
+  - chinese: 了
+    pinyin: le
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 语言
+    pinyin: yǔ yán
+  - chinese: ？
+    pinyin: ''
+  english: What languages did you study while in a foreign country?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 外国
+    pinyin: wài guó
+  - chinese: 交
+    pinyin: jiāo
+  - chinese: 到
+    pinyin: dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: ？
+    pinyin: ''
+  english: What kind of friends did you make while in a foreign country?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 哪些
+    pinyin: nǎ xiē
+  - chinese: 外语
+    pinyin: wài yǔ
+  - chinese: ？
+    pinyin: ''
+  english: Which foreign languages do you speak?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 学
+    pinyin: xué
+  - chinese: 西班牙语
+    pinyin: Xī bān yá yǔ
+  - chinese: 。
+    pinyin: ''
+  english: I'm studying Spanish.
+
+- segments:
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 外语
+    pinyin: wài yǔ
+  - chinese: 对
+    pinyin: duì
+  - chinese: 找
+    pinyin: zhǎo
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 帮助
+    pinyin: bāng zhù
+  - chinese: 。
+    pinyin: ''
+  english: Learning a foreign language is very helpful for finding a job.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 学
+    pinyin: xué
+  - chinese: 外语
+    pinyin: wài yǔ
+  - chinese: ？
+    pinyin: ''
+  english: Why do you want to learn a foreign language?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 语言
+    pinyin: yǔ yán
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 学
+    pinyin: xué
+  - chinese: 外语
+    pinyin: wài yǔ
+  - chinese: 。
+    pinyin: ''
+  english: You can go to a language school to study a foreign language.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 和
+    pinyin: hé
+  - chinese: 电视
+    pinyin: diàn shì
+  - chinese: 来
+    pinyin: lái
+  - chinese: 学
+    pinyin: xué
+  - chinese: 外语
+    pinyin: wài yǔ
+  - chinese: 。
+    pinyin: ''
+  english: You can learn a foreign language by watching movies and TV.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 找
+    pinyin: zhǎo
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 语言
+    pinyin: yǔ yán
+  - chinese: 交换
+    pinyin: jiāo huàn
+  - chinese: 伙伴
+    pinyin: huǒ bàn
+  - chinese: 来
+    pinyin: lái
+  - chinese: 练习
+    pinyin: liàn xí
+  - chinese: 口语
+    pinyin: kǒu yǔ
+  - chinese: 。
+    pinyin: ''
+  english: You can find a language exchange partner to practice speaking.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 下载
+    pinyin: xià zǎi
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 语言
+    pinyin: yǔ yán
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 应用
+    pinyin: yìng yòng
+  - chinese: 来
+    pinyin: lái
+  - chinese: 帮助
+    pinyin: bāng zhù
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 学
+    pinyin: xué
+  - chinese: 外语
+    pinyin: wài yǔ
+  - chinese: 。
+    pinyin: ''
+  english: You can download a language learning app to help you study a foreign language.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 网上
+    pinyin: wǎng shàng
+  - chinese: 认识
+    pinyin: rèn shi
+  - chinese: 了
+    pinyin: le
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 网友
+    pinyin: wǎng yǒu
+  - chinese: 。
+    pinyin: ''
+  english: I've met a lot of online friends.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 和
+    pinyin: hé
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 网友
+    pinyin: wǎng yǒu
+  - chinese: 在
+    pinyin: zài
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 店
+    pinyin: diàn
+  - chinese: 见面
+    pinyin: jiàn miàn
+  - chinese: 。
+    pinyin: ''
+  english: I met my online friend at a coffee shop.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 网友
+    pinyin: wǎng yǒu
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 推荐
+    pinyin: tuī jiàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: My online friend recommended a lot of good books to me.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 和
+    pinyin: hé
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 网友
+    pinyin: wǎng yǒu
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 得
+    pinyin: de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 开心
+    pinyin: kāi xīn
+  - chinese: 。
+    pinyin: ''
+  english: I had a great time with my online friend.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 和
+    pinyin: hé
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 网友
+    pinyin: wǎng yǒu
+  - chinese: 在
+    pinyin: zài
+  - chinese: 网上
+    pinyin: wǎng shàng
+  - chinese: 聊
+    pinyin: liáo
+  - chinese: 了
+    pinyin: le
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 次
+    pinyin: cì
+  - chinese: 。
+    pinyin: ''
+  english: I've chatted with my online friend many times.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 和
+    pinyin: hé
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 网友
+    pinyin: wǎng yǒu
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 共同
+    pinyin: gòng tóng
+  - chinese: 的
+    pinyin: de
+  - chinese: 爱好
+    pinyin: ài hào
+  - chinese: 。
+    pinyin: ''
+  english: My online friend and I share a lot of common interests.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 和
+    pinyin: hé
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 网友
+    pinyin: wǎng yǒu
+  - chinese: 从来
+    pinyin: cóng lái
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 见
+    pinyin: jiàn
+  - chinese: 过
+    pinyin: guò
+  - chinese: 面
+    pinyin: miàn
+  - chinese: 。
+    pinyin: ''
+  english: My online friend and I have never met in person.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 和
+    pinyin: hé
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 网友
+    pinyin: wǎng yǒu
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 相似
+    pinyin: xiāng sì
+  - chinese: 的
+    pinyin: de
+  - chinese: 性格
+    pinyin: xìng gé
+  - chinese: 。
+    pinyin: ''
+  english: My online friend and I have very similar personalities.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 过
+    pinyin: guò
+  - chinese: 午饭
+    pinyin: wǔ fàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I've had lunch.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 午饭
+    pinyin: wǔ fàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Have you had lunch?
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 午饭
+    pinyin: wǔ fàn
+  - chinese: 吧
+    pinyin: ba
+  - chinese: ！
+    pinyin: ''
+  english: Let's have lunch together!
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 午饭
+    pinyin: wǔ fàn
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 去
+    pinyin: qù
+  - chinese: 健身
+    pinyin: jiàn shēn
+  - chinese: 房
+    pinyin: fáng
+  - chinese: 。
+    pinyin: ''
+  english: I usually go to the gym during lunch time.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 午饭
+    pinyin: wǔ fàn
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 开会
+    pinyin: kāi huì
+  - chinese: 。
+    pinyin: ''
+  english: We have meetings during lunch time.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 午饭
+    pinyin: wǔ fàn
+  - chinese: ？
+    pinyin: ''
+  english: Where do you usually have lunch?
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 午饭
+    pinyin: wǔ fàn
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 休息
+    pinyin: xiū xi
+  - chinese: 。
+    pinyin: ''
+  english: We take a break during lunch time.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 午饭
+    pinyin: wǔ fàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 没
+    pinyin: méi
+  - chinese: ？
+    pinyin: ''
+  english: Have you had lunch yet?
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 西
+    pinyin: xī
+  - chinese: 区
+    pinyin: qū
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 办公室
+    pinyin: bàn gōng shì
+  - chinese: 。
+    pinyin: ''
+  english: We have an office in the western district.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 西
+    pinyin: xī
+  - chinese: 区
+    pinyin: qū
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 分店
+    pinyin: fēn diàn
+  - chinese: 。
+    pinyin: ''
+  english: We have a branch in the western area.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 西
+    pinyin: xī
+  - chinese: 区
+    pinyin: qū
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 体育场
+    pinyin: tǐ yù chǎng
+  - chinese: 。
+    pinyin: ''
+  english: We have a stadium in the western zone.
+
+- segments:
+  - chinese: 下课
+    pinyin: xià kè
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: 吧
+    pinyin: ba
+  - chinese: ！
+    pinyin: ''
+  english: Class is over, let's go get something to eat!
+
+- segments:
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: ，
+    pinyin: ''
+  - chinese: 下课
+    pinyin: xià kè
+  - chinese: 了
+    pinyin: le
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Teacher, is class over?
+
+- segments:
+  - chinese: 下课
+    pinyin: xià kè
+  - chinese: 铃
+    pinyin: líng
+  - chinese: 响
+    pinyin: xiǎng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: The bell for the end of class rang.
+
+- segments:
+  - chinese: 下课
+    pinyin: xià kè
+  - chinese: 后
+    pinyin: hòu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 篮球
+    pinyin: lán qiú
+  - chinese: 训练
+    pinyin: xùn liàn
+  - chinese: 。
+    pinyin: ''
+  english: After class, I have basketball practice.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 下课
+    pinyin: xià kè
+  - chinese: 了
+    pinyin: le
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 吧
+    pinyin: ba
+  - chinese: ！
+    pinyin: ''
+  english: Are you off class? Let's go get some coffee!
+
+- segments:
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 下课
+    pinyin: xià kè
+  - chinese: 后
+    pinyin: hòu
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 谈
+    pinyin: tán
+  - chinese: 谈
+    pinyin: tán
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Teacher, can I talk to you after class?
+
+- segments:
+  - chinese: 下课
+    pinyin: xià kè
+  - chinese: 后
+    pinyin: hòu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 图书馆
+    pinyin: tú shū guǎn
+  - chinese: 还书
+    pinyin: huán shū
+  - chinese: 。
+    pinyin: ''
+  english: After class, I need to return books to the library.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 下课
+    pinyin: xià kè
+  - chinese: 后
+    pinyin: hòu
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What do you usually do after class?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 问
+    pinyin: wèn
+  - chinese: 那
+    pinyin: nà
+  - chinese: 位
+    pinyin: wèi
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: 。
+    pinyin: ''
+  english: You can ask that gentleman.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 问
+    pinyin: wèn
+  - chinese: 问
+    pinyin: wèn
+  - chinese: 那
+    pinyin: nà
+  - chinese: 位
+    pinyin: wèi
+  - chinese: 小姐
+    pinyin: xiǎo jie
+  - chinese: 。
+    pinyin: ''
+  english: You can ask that young lady.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小孩儿
+    pinyin: xiǎo hái r
+  - chinese: 是
+    pinyin: shì
+  - chinese: 谁
+    pinyin: shéi
+  - chinese: 的
+    pinyin: de
+  - chinese: ？
+    pinyin: ''
+  english: Whose kid is that?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小孩儿
+    pinyin: xiǎo hái r
+  - chinese: ？
+    pinyin: ''
+  english: How many kids do you have?
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小孩儿
+    pinyin: xiǎo hái r
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哭
+    pinyin: kū
+  - chinese: 。
+    pinyin: ''
+  english: That kid is crying.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 小孩儿
+    pinyin: xiǎo hái r
+  - chinese: 多
+    pinyin: duō
+  - chinese: 大
+    pinyin: dà
+  - chinese: 了
+    pinyin: le
+  - chinese: ？
+    pinyin: ''
+  english: How old is your kid now?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 小孩儿
+    pinyin: xiǎo hái r
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 调皮
+    pinyin: tiáo pí
+  - chinese: 。
+    pinyin: ''
+  english: My kid is very naughty.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 小孩儿
+    pinyin: xiǎo hái r
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: ？
+    pinyin: ''
+  english: Where is your kid?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 小孩儿
+    pinyin: xiǎo hái r
+  - chinese: 读
+    pinyin: dú
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I'm going to read a book to my kid.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 小孩儿
+    pinyin: xiǎo hái r
+  - chinese: 在
+    pinyin: zài
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 样
+    pinyin: yàng
+  - chinese: ？
+    pinyin: ''
+  english: How is your kid doing in school?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 小朋友
+    pinyin: xiǎo péng yǒu
+  - chinese: 多
+    pinyin: duō
+  - chinese: 大
+    pinyin: dà
+  - chinese: 了
+    pinyin: le
+  - chinese: ？
+    pinyin: ''
+  english: How old is your little friend now?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 小朋友
+    pinyin: xiǎo péng yǒu
+  - chinese: 读
+    pinyin: dú
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I'm going to read a book to my little friend.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 小朋友
+    pinyin: xiǎo péng yǒu
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: ？
+    pinyin: ''
+  english: Where is your little friend?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 小朋友
+    pinyin: xiǎo péng yǒu
+  - chinese: 在
+    pinyin: zài
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 样
+    pinyin: yàng
+  - chinese: ？
+    pinyin: ''
+  english: How is your little friend doing in school?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 小朋友
+    pinyin: xiǎo péng yǒu
+  - chinese: 分享
+    pinyin: fēn xiǎng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 玩具
+    pinyin: wán jù
+  - chinese: 。
+    pinyin: ''
+  english: You can share your toys with your little friends.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 带
+    pinyin: dài
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 小朋友
+    pinyin: xiǎo péng yǒu
+  - chinese: 去
+    pinyin: qù
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 。
+    pinyin: ''
+  english: You can take your little friends to the park to play.
+
+- segments:
+  - chinese: 新年
+    pinyin: xīn nián
+  - chinese: 快乐
+    pinyin: kuài lè
+  - chinese: ！
+    pinyin: ''
+  english: Happy New Year!
+
+- segments:
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 的
+    pinyin: de
+  - chinese: 一
+    pinyin: yī
+  - chinese: 年
+    pinyin: nián
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 希望
+    pinyin: xī wàng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 一切
+    pinyin: yī qiè
+  - chinese: 顺利
+    pinyin: shùn lì
+  - chinese: 。
+    pinyin: ''
+  english: In the new year, I hope everything goes well for you.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 新年
+    pinyin: xīn nián
+  - chinese: 假期
+    pinyin: jià qī
+  - chinese: 去
+    pinyin: qù
+  - chinese: 滑雪
+    pinyin: huá xuě
+  - chinese: 。
+    pinyin: ''
+  english: We went skiing during the New Year holiday.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 新年
+    pinyin: xīn nián
+  - chinese: 假期
+    pinyin: jià qī
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 了
+    pinyin: le
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 好吃
+    pinyin: hǎo chī
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: We ate a lot of delicious food during the New Year holiday.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 新年
+    pinyin: xīn nián
+  - chinese: 假期
+    pinyin: jià qī
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 了
+    pinyin: le
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What did you do during the New Year holiday?
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 新年
+    pinyin: xīn nián
+  - chinese: 假期
+    pinyin: jià qī
+  - chinese: 去
+    pinyin: qù
+  - chinese: 了
+    pinyin: le
+  - chinese: 北京
+    pinyin: Běi jīng
+  - chinese: 。
+    pinyin: ''
+  english: We went to Beijing during the New Year holiday.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 新年
+    pinyin: xīn nián
+  - chinese: 假期
+    pinyin: jià qī
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 了
+    pinyin: le
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 烟花
+    pinyin: yān huā
+  - chinese: 。
+    pinyin: ''
+  english: We set off a lot of fireworks during the New Year holiday.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 新年
+    pinyin: xīn nián
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What do you usually do for the New Year?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 新年
+    pinyin: xīn nián
+  - chinese: 计划
+    pinyin: jì huà
+  - chinese: ？
+    pinyin: ''
+  english: What are your New Year's resolutions?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 艺术
+    pinyin: yì shù
+  - chinese: 学院
+    pinyin: xué yuàn
+  - chinese: 。
+    pinyin: ''
+  english: He attended an art college.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 所
+    pinyin: suǒ
+  - chinese: 医学
+    pinyin: yī xué
+  - chinese: 院
+    pinyin: yuàn
+  - chinese: 的
+    pinyin: de
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 。
+    pinyin: ''
+  english: She is a student at a medical college.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 所
+    pinyin: suǒ
+  - chinese: 著名
+    pinyin: zhù míng
+  - chinese: 的
+    pinyin: de
+  - chinese: 工程
+    pinyin: gōng chéng
+  - chinese: 学院
+    pinyin: xué yuàn
+  - chinese: 。
+    pinyin: ''
+  english: This is a renowned engineering college.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 所
+    pinyin: suǒ
+  - chinese: 法学
+    pinyin: fǎ xué
+  - chinese: 院
+    pinyin: yuàn
+  - chinese: 的
+    pinyin: de
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 。
+    pinyin: ''
+  english: He is a student at a law school.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 所
+    pinyin: suǒ
+  - chinese: 商
+    pinyin: shāng
+  - chinese: 学院
+    pinyin: xué yuàn
+  - chinese: 。
+    pinyin: ''
+  english: This is a business school.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 考虑
+    pinyin: kǎo lǜ
+  - chinese: 过
+    pinyin: guò
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 音乐
+    pinyin: yīn yuè
+  - chinese: 学院
+    pinyin: xué yuàn
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Have you considered attending a music college?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有没有
+    pinyin: yǒu méi yǒu
+  - chinese: 考虑
+    pinyin: kǎo lǜ
+  - chinese: 过
+    pinyin: guò
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 师范
+    pinyin: shī fàn
+  - chinese: 学院
+    pinyin: xué yuàn
+  - chinese: ？
+    pinyin: ''
+  english: Have you thought about attending a teacher's college?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 选择
+    pinyin: xuǎn zé
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 所
+    pinyin: suǒ
+  - chinese: 学院
+    pinyin: xué yuàn
+  - chinese: ？
+    pinyin: ''
+  english: Why did you choose to attend this college?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 所
+    pinyin: suǒ
+  - chinese: 学院
+    pinyin: xué yuàn
+  - chinese: 提供
+    pinyin: tí gōng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 不同
+    pinyin: bù tóng
+  - chinese: 的
+    pinyin: de
+  - chinese: 课程
+    pinyin: kè chéng
+  - chinese: 。
+    pinyin: ''
+  english: This college offers a lot of different courses.
+
+- segments:
+  - chinese: 有时候
+    pinyin: yǒu shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: Sometimes, I like to watch movies.
+
+- segments:
+  - chinese: 有时候
+    pinyin: yǒu shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 读
+    pinyin: dú
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: Sometimes, I like to read a book.
+
+- segments:
+  - chinese: 有时候
+    pinyin: yǒu shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 去
+    pinyin: qù
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 。
+    pinyin: ''
+  english: Sometimes, I like to go to the park.
+
+- segments:
+  - chinese: 有时候
+    pinyin: yǒu shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 音乐
+    pinyin: yīn yuè
+  - chinese: 。
+    pinyin: ''
+  english: Sometimes, I like to listen to music.
+
+- segments:
+  - chinese: 有时候
+    pinyin: yǒu shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 画
+    pinyin: huà
+  - chinese: 画
+    pinyin: huà
+  - chinese: 。
+    pinyin: ''
+  english: Sometimes, I like to draw.
+
+- segments:
+  - chinese: 有时候
+    pinyin: yǒu shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 写
+    pinyin: xiě
+  - chinese: 日记
+    pinyin: rì jì
+  - chinese: 。
+    pinyin: ''
+  english: Sometimes, I like to write a diary.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有时候
+    pinyin: yǒu shí hou
+  - chinese: 会
+    pinyin: huì
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What do you do sometimes?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有时候
+    pinyin: yǒu shí hou
+  - chinese: 会
+    pinyin: huì
+  - chinese: 去
+    pinyin: qù
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: ？
+    pinyin: ''
+  english: Where do you go sometimes?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有时候
+    pinyin: yǒu shí hou
+  - chinese: 会
+    pinyin: huì
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 运动
+    pinyin: yùn dòng
+  - chinese: ？
+    pinyin: ''
+  english: What kind of sports do you play sometimes?
+
+- segments:
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 聪明
+    pinyin: cōng ming
+  - chinese: 。
+    pinyin: ''
+  english: Some students are very smart.
+
+- segments:
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 人
+    pinyin: rén
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 夏天
+    pinyin: xià tiān
+  - chinese: ，
+    pinyin: ''
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 人
+    pinyin: rén
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 冬天
+    pinyin: dōng tiān
+  - chinese: 。
+    pinyin: ''
+  english: Some people like summer, some people like winter.
+
+- segments:
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 难
+    pinyin: nán
+  - chinese: 。
+    pinyin: ''
+  english: Some questions are very difficult.
+
+- segments:
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 书
+    pinyin: shū
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 便宜
+    pinyin: pián yi
+  - chinese: 。
+    pinyin: ''
+  english: Some books are very cheap.
+
+- segments:
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 无聊
+    pinyin: wú liáo
+  - chinese: 。
+    pinyin: ''
+  english: Some movies are very boring.
+
+- segments:
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 食物
+    pinyin: shí wù
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 辣
+    pinyin: là
+  - chinese: 。
+    pinyin: ''
+  english: Some foods are very spicy.
+
+- segments:
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 人
+    pinyin: rén
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 外向
+    pinyin: wài xiàng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 人
+    pinyin: rén
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 内向
+    pinyin: nèi xiàng
+  - chinese: 。
+    pinyin: ''
+  english: Some people are extroverted, some are introverted.
+
+- segments:
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 人
+    pinyin: rén
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 猫
+    pinyin: māo
+  - chinese: ，
+    pinyin: ''
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 人
+    pinyin: rén
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 狗
+    pinyin: gǒu
+  - chinese: 。
+    pinyin: ''
+  english: Some people like cats, some people like dogs.
+
+- segments:
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 人
+    pinyin: rén
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 早
+    pinyin: zǎo
+  - chinese: 起
+    pinyin: qǐ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 人
+    pinyin: rén
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 晚
+    pinyin: wǎn
+  - chinese: 睡
+    pinyin: shuì
+  - chinese: 。
+    pinyin: ''
+  english: Some people like to get up early, some people like to sleep late.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 信息
+    pinyin: xìn xī
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有用
+    pinyin: yǒu yòng
+  - chinese: 。
+    pinyin: ''
+  english: This information is very useful.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 建议
+    pinyin: jiàn yì
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有用
+    pinyin: yǒu yòng
+  - chinese: 。
+    pinyin: ''
+  english: The advice you gave me is very helpful.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 对
+    pinyin: duì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有用
+    pinyin: yǒu yòng
+  - chinese: 。
+    pinyin: ''
+  english: This book is very useful to me.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 的
+    pinyin: de
+  - chinese: 那些
+    pinyin: nà xiē
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 一点儿
+    pinyin: yī diǎn r
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 没
+    pinyin: méi
+  - chinese: 有用
+    pinyin: yǒu yòng
+  - chinese: 。
+    pinyin: ''
+  english: Those things you said are not useful at all.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 这些
+    pinyin: zhè xiē
+  - chinese: 有用
+    pinyin: yǒu yòng
+  - chinese: 的
+    pinyin: de
+  - chinese: 信息
+    pinyin: xìn xī
+  - chinese: 分享
+    pinyin: fēn xiǎng
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 别人
+    pinyin: bié ren
+  - chinese: 。
+    pinyin: ''
+  english: You can share this useful information with others.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 这些
+    pinyin: zhè xiē
+  - chinese: 有用
+    pinyin: yǒu yòng
+  - chinese: 的
+    pinyin: de
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 扔
+    pinyin: rēng
+  - chinese: 掉
+    pinyin: diào
+  - chinese: 。
+    pinyin: ''
+  english: You can throw away these useful things.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 这些
+    pinyin: zhè xiē
+  - chinese: 有用
+    pinyin: yǒu yòng
+  - chinese: 的
+    pinyin: de
+  - chinese: 信息
+    pinyin: xìn xī
+  - chinese: 记
+    pinyin: jì
+  - chinese: 下来
+    pinyin: xià lai
+  - chinese: 。
+    pinyin: ''
+  english: You can write down this useful information.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 这些
+    pinyin: zhè xiē
+  - chinese: 有用
+    pinyin: yǒu yòng
+  - chinese: 的
+    pinyin: de
+  - chinese: 建议
+    pinyin: jiàn yì
+  - chinese: 考虑
+    pinyin: kǎo lǜ
+  - chinese: 一下
+    pinyin: yī xià
+  - chinese: 。
+    pinyin: ''
+  english: You can consider this useful advice.
+
+- segments:
+  - chinese: 再见
+    pinyin: zài jiàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 祝
+    pinyin: zhù
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 一路
+    pinyin: yī lù
+  - chinese: 平安
+    pinyin: píng ān
+  - chinese: ！
+    pinyin: ''
+  english: Goodbye, wishing you a safe journey!
+
+- segments:
+  - chinese: 再见
+    pinyin: zài jiàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 希望
+    pinyin: xī wàng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 快
+    pinyin: kuài
+  - chinese: 能
+    pinyin: néng
+  - chinese: 再
+    pinyin: zài
+  - chinese: 见到
+    pinyin: jiàn dào
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: ！
+    pinyin: ''
+  english: Goodbye, hoping to see you again soon!
+
+- segments:
+  - chinese: 再见
+    pinyin: zài jiàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 下次
+    pinyin: xià cì
+  - chinese: 来
+    pinyin: lái
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 吧
+    pinyin: ba
+  - chinese: ！
+    pinyin: ''
+  english: Goodbye, come to my place next time!
+
+- segments:
+  - chinese: 再见
+    pinyin: zài jiàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 谢谢
+    pinyin: xiè xie
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 邀请
+    pinyin: yāo qǐng
+  - chinese: ！
+    pinyin: ''
+  english: Goodbye, thanks for the invitation!
+
+- segments:
+  - chinese: 再见
+    pinyin: zài jiàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 祝
+    pinyin: zhù
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 好运
+    pinyin: hǎo yùn
+  - chinese: ！
+    pinyin: ''
+  english: Goodbye, wishing you good luck!
+
+- segments:
+  - chinese: 再见
+    pinyin: zài jiàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 见
+    pinyin: jiàn
+  - chinese: ！
+    pinyin: ''
+  english: Goodbye, see you tomorrow!
+
+- segments:
+  - chinese: 再见
+    pinyin: zài jiàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 下次
+    pinyin: xià cì
+  - chinese: 聊
+    pinyin: liáo
+  - chinese: ！
+    pinyin: ''
+  english: Goodbye, let's chat next time!
+
+- segments:
+  - chinese: 再见
+    pinyin: zài jiàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 得
+    pinyin: děi
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 了
+    pinyin: le
+  - chinese: ！
+    pinyin: ''
+  english: Goodbye, I have to go now!
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 不想
+    pinyin: bù xiǎng
+  - chinese: 出去
+    pinyin: chū qù
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 在家
+    pinyin: zài jiā
+  - chinese: 休息
+    pinyin: xiū xi
+  - chinese: 。
+    pinyin: ''
+  english: I don't feel like going out today, I want to stay home and rest.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在家
+    pinyin: zài jiā
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: ，
+    pinyin: ''
+  - chinese: 所以
+    pinyin: suǒ yǐ
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 灵活
+    pinyin: líng huó
+  - chinese: 。
+    pinyin: ''
+  english: I work from home, so I have a lot of flexibility.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在家
+    pinyin: zài jiā
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 午饭
+    pinyin: wǔ fàn
+  - chinese: 。
+    pinyin: ''
+  english: I have lunch at home.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在家
+    pinyin: zài jiā
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 穿
+    pinyin: chuān
+  - chinese: 舒服
+    pinyin: shū fu
+  - chinese: 的
+    pinyin: de
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 。
+    pinyin: ''
+  english: When I'm at home, I like to wear comfortable clothes.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在家
+    pinyin: zài jiā
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 穿
+    pinyin: chuān
+  - chinese: 睡衣
+    pinyin: shuì yī
+  - chinese: 。
+    pinyin: ''
+  english: When I'm at home, I usually wear pajamas.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在家
+    pinyin: zài jiā
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: ，
+    pinyin: ''
+  - chinese: 所以
+    pinyin: suǒ yǐ
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 通勤
+    pinyin: tōng qín
+  - chinese: 。
+    pinyin: ''
+  english: I work from home, so I don't need to commute.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在家
+    pinyin: zài jiā
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电视
+    pinyin: diàn shì
+  - chinese: 。
+    pinyin: ''
+  english: When I'm at home, I usually watch TV.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在家
+    pinyin: zài jiā
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 音乐
+    pinyin: yīn yuè
+  - chinese: 。
+    pinyin: ''
+  english: When I'm at home, I usually listen to music.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 这儿
+    pinyin: zhè r
+  - chinese: 等
+    pinyin: děng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 。
+    pinyin: ''
+  english: I'm waiting for you here.
+
+- segments:
+  - chinese: 这儿
+    pinyin: zhè r
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 店
+    pinyin: diàn
+  - chinese: 。
+    pinyin: ''
+  english: There's a coffee shop here.
+
+- segments:
+  - chinese: 这儿
+    pinyin: zhè r
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 。
+    pinyin: ''
+  english: There's a park here.
+
+- segments:
+  - chinese: 这儿
+    pinyin: zhè r
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 图书馆
+    pinyin: tú shū guǎn
+  - chinese: 。
+    pinyin: ''
+  english: There's a library here.
+
+- segments:
+  - chinese: 这儿
+    pinyin: zhè r
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 博物馆
+    pinyin: bó wù guǎn
+  - chinese: 。
+    pinyin: ''
+  english: There's a museum here.
+
+- segments:
+  - chinese: 这儿
+    pinyin: zhè r
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 超市
+    pinyin: chāo shì
+  - chinese: 。
+    pinyin: ''
+  english: There's a supermarket here.
+
+- segments:
+  - chinese: 这儿
+    pinyin: zhè r
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 邮局
+    pinyin: yóu jú
+  - chinese: 。
+    pinyin: ''
+  english: There's a post office here.
+
+- segments:
+  - chinese: 这儿
+    pinyin: zhè r
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 银行
+    pinyin: yín háng
+  - chinese: 。
+    pinyin: ''
+  english: There's a bank here.
+
+- segments:
+  - chinese: 这儿
+    pinyin: zhè r
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 饭店
+    pinyin: fàn diàn
+  - chinese: 。
+    pinyin: ''
+  english: There's a hotel here.
+
+- segments:
+  - chinese: 这儿
+    pinyin: zhè r
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 医院
+    pinyin: yī yuàn
+  - chinese: 。
+    pinyin: ''
+  english: There's a hospital here.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 往
+    pinyin: wǎng
+  - chinese: 这边
+    pinyin: zhè biān
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 往
+    pinyin: wǎng
+  - chinese: 那
+    pinyin: nà
+  - chinese: 边
+    pinyin: biān
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 。
+    pinyin: ''
+  english: You walk over here, they walk over there.
+
+- segments:
+  - chinese: 这边
+    pinyin: zhè biān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 那儿
+    pinyin: nà r
+  - chinese: 野餐
+    pinyin: yě cān
+  - chinese: 。
+    pinyin: ''
+  english: There's a park over here, we can go there for a picnic.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 这边
+    pinyin: zhè biān
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 那边
+    pinyin: nà bian
+  - chinese: 。
+    pinyin: ''
+  english: You sit on this side, I'll sit on that side.
+
+- segments:
+  - chinese: 这边
+    pinyin: zhè biān
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: ，
+    pinyin: ''
+  - chinese: 那边
+    pinyin: nà bian
+  - chinese: 却
+    pinyin: què
+  - chinese: 在
+    pinyin: zài
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: 。
+    pinyin: ''
+  english: The weather is nice over here, but it's raining over there.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 这边
+    pinyin: zhè biān
+  - chinese: 等
+    pinyin: děng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 快
+    pinyin: kuài
+  - chinese: 回来
+    pinyin: huí lai
+  - chinese: 。
+    pinyin: ''
+  english: Wait for me over here, I'll be right back.
+
+- segments:
+  - chinese: 这边
+    pinyin: zhè biān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 空
+    pinyin: kòng
+  - chinese: 位
+    pinyin: wèi
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Is there a vacant seat over here?
+
+- segments:
+  - chinese: 这边
+    pinyin: zhè biān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 厕所
+    pinyin: cè suǒ
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Is there a restroom over here?
+
+- segments:
+  - chinese: 这边
+    pinyin: zhè biān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 银行
+    pinyin: yín háng
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Is there a bank over here?
+
+- segments:
+  - chinese: 这边
+    pinyin: zhè biān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 超市
+    pinyin: chāo shì
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Is there a supermarket over here?
+
+- segments:
+  - chinese: 这边
+    pinyin: zhè biān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 邮局
+    pinyin: yóu jú
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Is there a post office over here?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 真的
+    pinyin: zhēn de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 抱歉
+    pinyin: bào qiàn
+  - chinese: 。
+    pinyin: ''
+  english: I am truly sorry.
+
+- segments:
+  - chinese: 真的
+    pinyin: zhēn de
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 骗
+    pinyin: piàn
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 。
+    pinyin: ''
+  english: Really, I'm not lying to you.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 真的
+    pinyin: zhēn de
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  - chinese: 它
+    pinyin: tā
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 远
+    pinyin: yuǎn
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: Are you sure you want to go? It's very far.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 真的
+    pinyin: zhēn de
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 次
+    pinyin: cì
+  - chinese: 美好
+    pinyin: měi hǎo
+  - chinese: 的
+    pinyin: de
+  - chinese: 经历
+    pinyin: jīng lì
+  - chinese: 。
+    pinyin: ''
+  english: This was truly a wonderful experience.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 真的
+    pinyin: zhēn de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 它
+    pinyin: tā
+  - chinese: ！
+    pinyin: ''
+  english: I really like this dress, I'm going to buy it!
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 真的
+    pinyin: zhēn de
+  - chinese: 太
+    pinyin: tài
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 了
+    pinyin: le
+  - chinese: 这么
+    pinyin: zhè me
+  - chinese: 多
+    pinyin: duō
+  - chinese: 。
+    pinyin: ''
+  english: You're truly too kind, helping me with so much.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 食物
+    pinyin: shí wù
+  - chinese: 真的
+    pinyin: zhēn de
+  - chinese: 太
+    pinyin: tài
+  - chinese: 辣
+    pinyin: là
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 不
+    pinyin: bù
+  - chinese: 了
+    pinyin: liǎo
+  - chinese: 。
+    pinyin: ''
+  english: This food is really too spicy, I can't eat it.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 得
+    pinyin: de
+  - chinese: 正
+    pinyin: zhèng
+  - chinese: 。
+    pinyin: ''
+  english: What you said is right.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 弘扬
+    pinyin: hóng yáng
+  - chinese: 正
+    pinyin: zhèng
+  - chinese: 能量
+    pinyin: néng liàng
+  - chinese: 。
+    pinyin: ''
+  english: We should promote positive energy.
+
+- segments:
+  - chinese: 政府
+    pinyin: zhèng fǔ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 责任
+    pinyin: zé rèn
+  - chinese: 维护
+    pinyin: wéi hù
+  - chinese: 正
+    pinyin: zhèng
+  - chinese: 。
+    pinyin: ''
+  english: The government has a responsibility to uphold justice.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 必须
+    pinyin: bì xū
+  - chinese: 正
+    pinyin: zhèng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 犯
+    pinyin: fàn
+  - chinese: 的
+    pinyin: de
+  - chinese: 错误
+    pinyin: cuò wù
+  - chinese: 。
+    pinyin: ''
+  english: You must correct the mistakes you made.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 正
+    pinyin: zhèng
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 事情
+    pinyin: shì qing
+  - chinese: 。
+    pinyin: ''
+  english: She is handling this matter.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 背
+    pinyin: bèi
+  - chinese: 挺
+    pinyin: tǐng
+  - chinese: 正
+    pinyin: zhèng
+  - chinese: 。
+    pinyin: ''
+  english: Please keep your back straight.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 对话
+    pinyin: duì huà
+  - chinese: 中间
+    pinyin: zhōng jiān
+  - chinese: 暂停
+    pinyin: zàn tíng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: They paused in the middle of the conversation.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 的
+    pinyin: de
+  - chinese: 中间
+    pinyin: zhōng jiān
+  - chinese: 部分
+    pinyin: bù fen
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 意思
+    pinyin: yì si
+  - chinese: 。
+    pinyin: ''
+  english: The middle part of this book is the most interesting.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 旅途
+    pinyin: lǚ tú
+  - chinese: 中间
+    pinyin: zhōng jiān
+  - chinese: 停留
+    pinyin: tíng liú
+  - chinese: 了
+    pinyin: le
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 天
+    pinyin: tiān
+  - chinese: 。
+    pinyin: ''
+  english: We took a break for a few days in the middle of our journey.
+
+- segments:
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 中间
+    pinyin: zhōng jiān
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 一
+    pinyin: yī
+  - chinese: 瓶
+    pinyin: píng
+  - chinese: 花
+    pinyin: huā
+  - chinese: 。
+    pinyin: ''
+  english: There is a vase of flowers in the middle of the table.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 中间
+    pinyin: zhōng jiān
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 排
+    pinyin: pái
+  - chinese: 。
+    pinyin: ''
+  english: They are sitting in the middle rows.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 考试
+    pinyin: kǎo shì
+  - chinese: 的
+    pinyin: de
+  - chinese: 中间
+    pinyin: zhōng jiān
+  - chinese: 不能
+    pinyin: bù néng
+  - chinese: 交谈
+    pinyin: jiāo tán
+  - chinese: 。
+    pinyin: ''
+  english: We can't talk in the middle of the exam.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 蛋黄酱
+    pinyin: dàn huáng jiàng
+  - chinese: 涂
+    pinyin: tú
+  - chinese: 在
+    pinyin: zài
+  - chinese: 面包
+    pinyin: miàn bāo
+  - chinese: 的
+    pinyin: de
+  - chinese: 中间
+    pinyin: zhōng jiān
+  - chinese: 。
+    pinyin: ''
+  english: You can spread the mayonnaise in the middle of the bread.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 的
+    pinyin: de
+  - chinese: 中间
+    pinyin: zhōng jiān
+  - chinese: 进来
+    pinyin: jìn lái
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: We came in the middle of the movie.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 中学
+    pinyin: zhōng xué
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 了
+    pinyin: le
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 科目
+    pinyin: kē mù
+  - chinese: 。
+    pinyin: ''
+  english: I studied a lot of subjects when I was in middle school.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 所
+    pinyin: suǒ
+  - chinese: 私立
+    pinyin: sī lì
+  - chinese: 中学
+    pinyin: zhōng xué
+  - chinese: 。
+    pinyin: ''
+  english: She attended a private middle school.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 中学
+    pinyin: zhōng xué
+  - chinese: 教育
+    pinyin: jiào yù
+  - chinese: 为
+    pinyin: wèi
+  - chinese: 他
+    pinyin: tā
+  - chinese: 打
+    pinyin: dǎ
+  - chinese: 下
+    pinyin: xià
+  - chinese: 了
+    pinyin: le
+  - chinese: 坚实
+    pinyin: jiān shí
+  - chinese: 的
+    pinyin: de
+  - chinese: 基础
+    pinyin: jī chǔ
+  - chinese: 。
+    pinyin: ''
+  english: His middle school education provided him with a solid foundation.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 中学
+    pinyin: zhōng xué
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 学
+    pinyin: xué
+  - chinese: 到
+    pinyin: dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 重要
+    pinyin: zhòng yào
+  - chinese: 的
+    pinyin: de
+  - chinese: 生活
+    pinyin: shēng huó
+  - chinese: 技能
+    pinyin: jì néng
+  - chinese: 。
+    pinyin: ''
+  english: We learned a lot of important life skills in middle school.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 中学
+    pinyin: zhōng xué
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 哪些
+    pinyin: nǎ xiē
+  - chinese: 科目
+    pinyin: kē mù
+  - chinese: ？
+    pinyin: ''
+  english: Which subjects did you like when you were in middle school?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 所
+    pinyin: suǒ
+  - chinese: 中学
+    pinyin: zhōng xué
+  - chinese: 以
+    pinyin: yǐ
+  - chinese: 优秀
+    pinyin: yōu xiù
+  - chinese: 的
+    pinyin: de
+  - chinese: 体育
+    pinyin: tǐ yù
+  - chinese: 教育
+    pinyin: jiào yù
+  - chinese: 而
+    pinyin: ér
+  - chinese: 闻名
+    pinyin: wén míng
+  - chinese: 。
+    pinyin: ''
+  english: This middle school is renowned for its excellent physical education program.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 中学
+    pinyin: zhōng xué
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 对
+    pinyin: duì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 影响
+    pinyin: yǐng xiǎng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 大
+    pinyin: dà
+  - chinese: 。
+    pinyin: ''
+  english: My middle school teachers had a big influence on me.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 仍然
+    pinyin: réng rán
+  - chinese: 保持
+    pinyin: bǎo chí
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 每
+    pinyin: měi
+  - chinese: 年
+    pinyin: nián
+  - chinese: 一次
+    pinyin: yī cì
+  - chinese: 的
+    pinyin: de
+  - chinese: 中学
+    pinyin: zhōng xué
+  - chinese: 同学
+    pinyin: tóng xué
+  - chinese: 聚会
+    pinyin: jù huì
+  - chinese: 。
+    pinyin: ''
+  english: They still hold an annual reunion for their middle school classmates.
+
+- segments:
+  - chinese: 书
+    pinyin: shū
+  - chinese: 在
+    pinyin: zài
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 的
+    pinyin: de
+  - chinese: 左边
+    pinyin: zuǒ bian
+  - chinese: 。
+    pinyin: ''
+  english: The book is on the left side of the desk.
+
+- segments:
+  - chinese: 博物馆
+    pinyin: bó wù guǎn
+  - chinese: 在
+    pinyin: zài
+  - chinese: 银行
+    pinyin: yín háng
+  - chinese: 的
+    pinyin: de
+  - chinese: 左边
+    pinyin: zuǒ bian
+  - chinese: 。
+    pinyin: ''
+  english: The museum is on the left side of the bank.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 地图
+    pinyin: dì tú
+  - chinese: 翻
+    pinyin: fān
+  - chinese: 到
+    pinyin: dào
+  - chinese: 左边
+    pinyin: zuǒ bian
+  - chinese: 那
+    pinyin: nà
+  - chinese: 页
+    pinyin: yè
+  - chinese: 。
+    pinyin: ''
+  english: Turn the map to the page on the left.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 车子
+    pinyin: chē zi
+  - chinese: 的
+    pinyin: de
+  - chinese: 左边
+    pinyin: zuǒ bian
+  - chinese: 。
+    pinyin: ''
+  english: He is on the left side of the car.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 左边
+    pinyin: zuǒ bian
+  - chinese: 耳朵
+    pinyin: ěr duo
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 不见
+    pinyin: bù jiàn
+  - chinese: 。
+    pinyin: ''
+  english: I can't hear out of my left ear.
+
+- segments:
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 椅子
+    pinyin: yǐ zi
+  - chinese: 的
+    pinyin: de
+  - chinese: 左边
+    pinyin: zuǒ bian
+  - chinese: 。
+    pinyin: ''
+  english: The cat is sitting on the left side of the chair.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 花瓶
+    pinyin: huā píng
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 的
+    pinyin: de
+  - chinese: 左边
+    pinyin: zuǒ bian
+  - chinese: 。
+    pinyin: ''
+  english: Put the vase on the left side of the table.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 左
+    pinyin: zuǒ
+  - chinese: 脚
+    pinyin: jiǎo
+  - chinese: 受伤
+    pinyin: shòu shāng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: My left foot is injured.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 教室
+    pinyin: jiào shì
+  - chinese: 的
+    pinyin: de
+  - chinese: 左
+    pinyin: zuǒ
+  - chinese: 后方
+    pinyin: hòu fāng
+  - chinese: 。
+    pinyin: ''
+  english: We sit in the back left of the classroom.
+
+- segments:
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 在
+    pinyin: zài
+  - chinese: 银行
+    pinyin: yín háng
+  - chinese: 的
+    pinyin: de
+  - chinese: 左侧
+    pinyin: zuǒ cè
+  - chinese: 。
+    pinyin: ''
+  english: The store is on the left side of the bank.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 好看
+    pinyin: hǎo kàn
+  - chinese: ！
+    pinyin: ''
+  english: She is so good-looking!
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 适合
+    pinyin: shì hé
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 穿上
+    pinyin: chuān shang
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 好看
+    pinyin: hǎo kàn
+  - chinese: 。
+    pinyin: ''
+  english: This dress suits you well, you look great in it!
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 头发
+    pinyin: tóu fa
+  - chinese: 剪
+    pinyin: jiǎn
+  - chinese: 短
+    pinyin: duǎn
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 好看
+    pinyin: hǎo kàn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: You cut your hair short, it looks so much better!
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 幅
+    pinyin: fú
+  - chinese: 画
+    pinyin: huà
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 好看
+    pinyin: hǎo kàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 它
+    pinyin: tā
+  - chinese: 挂
+    pinyin: guà
+  - chinese: 在
+    pinyin: zài
+  - chinese: 墙
+    pinyin: qiáng
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 。
+    pinyin: ''
+  english: This painting is so beautiful, I want to hang it on the wall.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 种
+    pinyin: zhòng
+  - chinese: 的
+    pinyin: de
+  - chinese: 花
+    pinyin: huā
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 好看
+    pinyin: hǎo kàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 开
+    pinyin: kāi
+  - chinese: 得
+    pinyin: de
+  - chinese: 那么
+    pinyin: nà me
+  - chinese: 茂盛
+    pinyin: mào shèng
+  - chinese: 。
+    pinyin: ''
+  english: The flowers you planted are so pretty, they're blooming so vigorously!
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 部
+    pinyin: bù
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 好看
+    pinyin: hǎo kàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 过
+    pinyin: guò
+  - chinese: 了
+    pinyin: le
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: This movie is really good, have you seen it?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 的
+    pinyin: de
+  - chinese: 蛋糕
+    pinyin: dàn gāo
+  - chinese: 不仅
+    pinyin: bù jǐn
+  - chinese: 好吃
+    pinyin: hǎo chī
+  - chinese: ，
+    pinyin: ''
+  - chinese: 而且
+    pinyin: ér qiě
+  - chinese: 好看
+    pinyin: hǎo kàn
+  - chinese: 。
+    pinyin: ''
+  english: The cake you made is not only delicious but also looks wonderful!
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 吧
+    pinyin: ba
+  - chinese: ，
+    pinyin: ''
+  - chinese: 那儿
+    pinyin: nà r
+  - chinese: 好玩儿
+    pinyin: hǎo wán r
+  - chinese: 极了
+    pinyin: jí le
+  - chinese: ！
+    pinyin: ''
+  english: Let's go together, it's so much fun over there!
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 游戏
+    pinyin: yóu xì
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 好玩儿
+    pinyin: hǎo wán r
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 了
+    pinyin: le
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: 。
+    pinyin: ''
+  english: This game is really fun, I played for several hours.
+
+- segments:
+  - chinese: 昨晚
+    pinyin: zuó wǎn
+  - chinese: 的
+    pinyin: de
+  - chinese: 派对
+    pinyin: pài duì
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 好玩儿
+    pinyin: hǎo wán r
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 跳
+    pinyin: tiào
+  - chinese: 了
+    pinyin: le
+  - chinese: 整
+    pinyin: zhěng
+  - chinese: 晚
+    pinyin: wǎn
+  - chinese: 的
+    pinyin: de
+  - chinese: 舞
+    pinyin: wǔ
+  - chinese: 。
+    pinyin: ''
+  english: The party last night was so fun, I danced the whole evening.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 城市
+    pinyin: chéng shì
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 好多
+    pinyin: hǎo duō
+  - chinese: 好玩儿
+    pinyin: hǎo wán r
+  - chinese: 的
+    pinyin: de
+  - chinese: 地方
+    pinyin: dì fāng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 去
+    pinyin: qù
+  - chinese: 探索
+    pinyin: tàn suǒ
+  - chinese: 吧
+    pinyin: ba
+  - chinese: ！
+    pinyin: ''
+  english: There are so many fun places in this city, let's go explore!
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 过
+    pinyin: guò
+  - chinese: 那个
+    pinyin: nà ge
+  - chinese: 主题
+    pinyin: zhǔ tí
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 听说
+    pinyin: tīng shuō
+  - chinese: 那里
+    pinyin: nà li
+  - chinese: 好玩儿
+    pinyin: hǎo wán r
+  - chinese: 得
+    pinyin: de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 。
+    pinyin: ''
+  english: Have you been to that theme park? I heard it's a lot of fun.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 得
+    pinyin: de
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 开心
+    pinyin: kāi xīn
+  - chinese: 啊
+    pinyin: a
+  - chinese: ，
+    pinyin: ''
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 还
+    pinyin: hái
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 再
+    pinyin: zài
+  - chinese: 去
+    pinyin: qù
+  - chinese: 一
+    pinyin: yī
+  - chinese: 次
+    pinyin: cì
+  - chinese: ！
+    pinyin: ''
+  english: We had so much fun, we want to go again tomorrow!
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 人群
+    pinyin: rén qún
+  - chinese: 的
+    pinyin: de
+  - chinese: 后边
+    pinyin: hòu bian
+  - chinese: 。
+    pinyin: ''
+  english: He is at the back of the crowd.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 车
+    pinyin: chē
+  - chinese: 跟着
+    pinyin: gēn zhe
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 车
+    pinyin: chē
+  - chinese: 的
+    pinyin: de
+  - chinese: 后边
+    pinyin: hòu bian
+  - chinese: 。
+    pinyin: ''
+  english: My car is following behind your car.
+
+- segments:
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 的
+    pinyin: de
+  - chinese: 后半
+    pinyin: hòu bàn
+  - chinese: 部分
+    pinyin: bù fen
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 感人
+    pinyin: gǎn rén
+  - chinese: 。
+    pinyin: ''
+  english: The latter part of the movie is very touching.
+
+- segments:
+  - chinese: 后边
+    pinyin: hòu bian
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 章
+    pinyin: zhāng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 精彩
+    pinyin: jīng cǎi
+  - chinese: 的
+    pinyin: de
+  - chinese: 部分
+    pinyin: bù fen
+  - chinese: 。
+    pinyin: ''
+  english: The last two chapters are the most exciting part of the book.
+
+- segments:
+  - chinese: 后边
+    pinyin: hòu bian
+  - chinese: 还有
+    pinyin: hái yǒu
+  - chinese: 更
+    pinyin: gèng
+  - chinese: 多
+    pinyin: duō
+  - chinese: 精彩
+    pinyin: jīng cǎi
+  - chinese: 的
+    pinyin: de
+  - chinese: 表演
+    pinyin: biǎo yǎn
+  - chinese: 呢
+    pinyin: ne
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不要
+    pinyin: bù yào
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: ！
+    pinyin: ''
+  english: There are more wonderful performances coming up, don't leave!
+
+- segments:
+  - chinese: 后边
+    pinyin: hòu bian
+  - chinese: 那
+    pinyin: nà
+  - chinese: 栋
+    pinyin: dòng
+  - chinese: 大楼
+    pinyin: dà lóu
+  - chinese: 是
+    pinyin: shì
+  - chinese: 市政府
+    pinyin: shì zhèng fǔ
+  - chinese: 。
+    pinyin: ''
+  english: The building behind is the city hall.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 回到
+    pinyin: huí dào
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 已经
+    pinyin: yǐ jīng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 晚
+    pinyin: wǎn
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: By the time I returned home, it was already very late.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 回到
+    pinyin: huí dào
+  - chinese: 酒店
+    pinyin: jiǔ diàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 发现
+    pinyin: fā xiàn
+  - chinese: 钱包
+    pinyin: qián bāo
+  - chinese: 不见
+    pinyin: bù jiàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: When they returned to the hotel, they realized their wallet was missing.
+
+- segments:
+  - chinese: 回到
+    pinyin: huí dào
+  - chinese: 过去
+    pinyin: guò qù
+  - chinese: 是
+    pinyin: shì
+  - chinese: 不
+    pinyin: bù
+  - chinese: 可能
+    pinyin: kě néng
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: It's impossible to go back to the past.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 回到
+    pinyin: huí dào
+  - chinese: 起点
+    pinyin: qǐ diǎn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 重新
+    pinyin: chóng xīn
+  - chinese: 开始
+    pinyin: kāi shǐ
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Let's go back to the starting point and start over.
+
+- segments:
+  - chinese: 回到
+    pinyin: huí dào
+  - chinese: 自然
+    pinyin: zì rán
+  - chinese: ，
+    pinyin: ''
+  - chinese: 享受
+    pinyin: xiǎng shòu
+  - chinese: 宁静
+    pinyin: níng jìng
+  - chinese: 的
+    pinyin: de
+  - chinese: 生活
+    pinyin: shēng huó
+  - chinese: 。
+    pinyin: ''
+  english: Return to nature and enjoy a peaceful life.
+
+- segments:
+  - chinese: 回到
+    pinyin: huí dào
+  - chinese: 童年
+    pinyin: tóng nián
+  - chinese: 时光
+    pinyin: shí guāng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 无忧无虑
+    pinyin: wú yōu wú lǜ
+  - chinese: 地
+    pinyin: de
+  - chinese: 玩耍
+    pinyin: wán shuǎ
+  - chinese: 。
+    pinyin: ''
+  english: Going back to childhood times, playing carefree.
+
+- segments:
+  - chinese: 回到
+    pinyin: huí dào
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 后
+    pinyin: hòu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 先
+    pinyin: xiān
+  - chinese: 检查
+    pinyin: jiǎn chá
+  - chinese: 邮件
+    pinyin: yóu jiàn
+  - chinese: 。
+    pinyin: ''
+  english: When I get home, I usually check the mail first.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 回去
+    pinyin: huí qu
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I'm going back.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 回去
+    pinyin: huí qu
+  - chinese: 。
+    pinyin: ''
+  english: They will go back tomorrow.
+
+- segments:
+  - chinese: 回去
+    pinyin: huí qu
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 记得
+    pinyin: jì de
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 一些
+    pinyin: yī xiē
+  - chinese: 水果
+    pinyin: shuǐ guǒ
+  - chinese: 。
+    pinyin: ''
+  english: When you go back, remember to buy some fruit.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 回去
+    pinyin: huí qu
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 午饭
+    pinyin: wǔ fàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I'm going back to have lunch.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 回去
+    pinyin: huí qu
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 只
+    pinyin: zhǐ
+  - chinese: 留
+    pinyin: liú
+  - chinese: 下
+    pinyin: xià
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 告别
+    pinyin: gào bié
+  - chinese: 的
+    pinyin: de
+  - chinese: 纸条
+    pinyin: zhǐ tiáo
+  - chinese: 。
+    pinyin: ''
+  english: They went back, leaving only a farewell note.
+
+- segments:
+  - chinese: 回去
+    pinyin: huí qu
+  - chinese: 的
+    pinyin: de
+  - chinese: 路
+    pinyin: lù
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 危险
+    pinyin: wēi xiǎn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 要
+    pinyin: yào
+  - chinese: 小心
+    pinyin: xiǎo xīn
+  - chinese: 。
+    pinyin: ''
+  english: The way back is dangerous, be careful.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 回去
+    pinyin: huí qu
+  - chinese: 上学
+    pinyin: shàng xué
+  - chinese: ？
+    pinyin: ''
+  english: When are you going back to school?
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 决定
+    pinyin: jué dìng
+  - chinese: 今年
+    pinyin: jīn nián
+  - chinese: 不
+    pinyin: bù
+  - chinese: 回去
+    pinyin: huí qu
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: They decided not to go back this year.
+
+- segments:
+  - chinese: 记住
+    pinyin: jì zhu
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 电话
+    pinyin: diàn huà
+  - chinese: 号码
+    pinyin: hào mǎ
+  - chinese: 。
+    pinyin: ''
+  english: Remember my phone number.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 的
+    pinyin: de
+  - chinese: 话
+    pinyin: huà
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 记住
+    pinyin: jì zhu
+  - chinese: 。
+    pinyin: ''
+  english: Remember what I said.
+
+- segments:
+  - chinese: 考试
+    pinyin: kǎo shì
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 记住
+    pinyin: jì zhu
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 限制
+    pinyin: xiàn zhì
+  - chinese: 。
+    pinyin: ''
+  english: During the exam, remember the time limit.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 必须
+    pinyin: bì xū
+  - chinese: 记住
+    pinyin: jì zhu
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 教训
+    pinyin: jiào xun
+  - chinese: 。
+    pinyin: ''
+  english: You must remember this lesson.
+
+- segments:
+  - chinese: 记住
+    pinyin: jì zhu
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 垃圾
+    pinyin: lā jī
+  - chinese: 分
+    pinyin: fēn
+  - chinese: 类
+    pinyin: lèi
+  - chinese: 。
+    pinyin: ''
+  english: Remember to sort the trash.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 记住
+    pinyin: jì zhu
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 生日
+    pinyin: shēng rì
+  - chinese: 了
+    pinyin: le
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you remember her birthday?
+
+- segments:
+  - chinese: 记住
+    pinyin: jì zhu
+  - chinese: 随时
+    pinyin: suí shí
+  - chinese: 锁
+    pinyin: suǒ
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 门
+    pinyin: mén
+  - chinese: 窗
+    pinyin: chuāng
+  - chinese: 。
+    pinyin: ''
+  english: Remember to lock the doors and windows at all times.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 考
+    pinyin: kǎo
+  - chinese: 哪
+    pinyin: nǎ
+  - chinese: 所
+    pinyin: suǒ
+  - chinese: 大学
+    pinyin: dà xué
+  - chinese: ？
+    pinyin: ''
+  english: Which university do you want to apply to?
+
+- segments:
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 要
+    pinyin: yào
+  - chinese: 考
+    pinyin: kǎo
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 数学
+    pinyin: shù xué
+  - chinese: 。
+    pinyin: ''
+  english: The teacher is going to test us on math.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 考
+    pinyin: kǎo
+  - chinese: 得
+    pinyin: de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: I did well on the exam.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 考完
+    pinyin: kǎo wán
+  - chinese: 试
+    pinyin: shì
+  - chinese: ？
+    pinyin: ''
+  english: When will you finish your exams?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 考
+    pinyin: kǎo
+  - chinese: 到
+    pinyin: dào
+  - chinese: 任何
+    pinyin: rèn hé
+  - chinese: 有用
+    pinyin: yǒu yòng
+  - chinese: 的
+    pinyin: de
+  - chinese: 信息
+    pinyin: xìn xī
+  - chinese: 了
+    pinyin: le
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Have you found out any useful information?
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 节
+    pinyin: jiē
+  - chinese: 课
+    pinyin: kè
+  - chinese: ？
+    pinyin: ''
+  english: How many classes do we have today?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 门
+    pinyin: mén
+  - chinese: 课
+    pinyin: kè
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有趣
+    pinyin: yǒu qù
+  - chinese: 。
+    pinyin: ''
+  english: This class is very interesting.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 的
+    pinyin: de
+  - chinese: 历史
+    pinyin: lì shǐ
+  - chinese: 课
+    pinyin: kè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 古
+    pinyin: gǔ
+  - chinese: 埃及
+    pinyin: Āi jí
+  - chinese: 历史
+    pinyin: lì shǐ
+  - chinese: 。
+    pinyin: ''
+  english: My favorite history course is Ancient Egyptian History.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 学期
+    pinyin: xué qī
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 选
+    pinyin: xuǎn
+  - chinese: 了
+    pinyin: le
+  - chinese: 三
+    pinyin: sān
+  - chinese: 门
+    pinyin: mén
+  - chinese: 课
+    pinyin: kè
+  - chinese: 。
+    pinyin: ''
+  english: I chose three courses for this semester.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 门
+    pinyin: mén
+  - chinese: 课
+    pinyin: kè
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 阅读
+    pinyin: yuè dú
+  - chinese: 。
+    pinyin: ''
+  english: This course requires a lot of reading.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 的
+    pinyin: de
+  - chinese: 课
+    pinyin: kè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What's your favorite class?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 门
+    pinyin: mén
+  - chinese: 课
+    pinyin: kè
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 重
+    pinyin: zhòng
+  - chinese: 的
+    pinyin: de
+  - chinese: 作业
+    pinyin: zuò yè
+  - chinese: 负担
+    pinyin: fù dān
+  - chinese: 。
+    pinyin: ''
+  english: This course has a heavy workload.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 老
+    pinyin: lǎo
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: This is an old book.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 餐馆
+    pinyin: cān guǎn
+  - chinese: 是
+    pinyin: shì
+  - chinese: 老
+    pinyin: lǎo
+  - chinese: 字号
+    pinyin: zì hào
+  - chinese: ，
+    pinyin: ''
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有名
+    pinyin: yǒu míng
+  - chinese: 。
+    pinyin: ''
+  english: This restaurant is a long-established one and is quite famous.
+
+- segments:
+  - chinese: 盒子
+    pinyin: hé zi
+  - chinese: 里边
+    pinyin: lǐ bian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What's inside the box?
+
+- segments:
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 里边
+    pinyin: lǐ bian
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 暖和
+    pinyin: nuǎn huo
+  - chinese: 。
+    pinyin: ''
+  english: The room is nice and warm inside.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 到
+    pinyin: dào
+  - chinese: 里边
+    pinyin: lǐ bian
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Come and sit inside.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 里边
+    pinyin: lǐ bian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 有趣
+    pinyin: yǒu qù
+  - chinese: 的
+    pinyin: de
+  - chinese: 故事
+    pinyin: gù shì
+  - chinese: 。
+    pinyin: ''
+  english: There are many interesting stories inside this book.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 从
+    pinyin: cóng
+  - chinese: 外边
+    pinyin: wài bian
+  - chinese: 看到
+    pinyin: kàn dào
+  - chinese: 里边
+    pinyin: lǐ bian
+  - chinese: 。
+    pinyin: ''
+  english: You can see the inside from the outside.
+
+- segments:
+  - chinese: 里边
+    pinyin: lǐ bian
+  - chinese: 的
+    pinyin: de
+  - chinese: 人
+    pinyin: rén
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 不
+    pinyin: bù
+  - chinese: 到
+    pinyin: dào
+  - chinese: 外边
+    pinyin: wài bian
+  - chinese: 。
+    pinyin: ''
+  english: The people inside can't see outside.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 盒子
+    pinyin: hé zi
+  - chinese: 里边
+    pinyin: lǐ bian
+  - chinese: 。
+    pinyin: ''
+  english: You can put things inside the box.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 信
+    pinyin: xìn
+  - chinese: 里边
+    pinyin: lǐ bian
+  - chinese: 写
+    pinyin: xiě
+  - chinese: 了
+    pinyin: le
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you know what's written inside the letter?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 别的
+    pinyin: bié de
+  - chinese: 选择
+    pinyin: xuǎn zé
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you have any other choices?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 别的
+    pinyin: bié de
+  - chinese: 办法
+    pinyin: bàn fǎ
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I don't have any other options.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 别的
+    pinyin: bié de
+  - chinese: 建议
+    pinyin: jiàn yì
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you have any other suggestions?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 饭店
+    pinyin: fàn diàn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 别的
+    pinyin: bié de
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Does this restaurant have any other dishes?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不想
+    pinyin: bù xiǎng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 别的
+    pinyin: bié de
+  - chinese: 地方
+    pinyin: dì fang
+  - chinese: 。
+    pinyin: ''
+  english: I don't want to go anywhere else.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 别的
+    pinyin: bié de
+  - chinese: 鞋子
+    pinyin: xié zi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 借
+    pinyin: jiè
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you have any other shoes I can borrow?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 别的
+    pinyin: bié de
+  - chinese: 兴趣
+    pinyin: xìng qù
+  - chinese: 爱好
+    pinyin: ài hào
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you have any other hobbies or interests?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 别的
+    pinyin: bié de
+  - chinese: 颜色
+    pinyin: yán sè
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Does this dress come in any other colors?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 别的
+    pinyin: bié de
+  - chinese: 解释
+    pinyin: jiě shì
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you have any other explanations?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 不大
+    pinyin: bù dà
+  - chinese: 。
+    pinyin: ''
+  english: This room is not very big.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 对
+    pinyin: duì
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 不大
+    pinyin: bù dà
+  - chinese: 了解
+    pinyin: liǎo jiě
+  - chinese: 。
+    pinyin: ''
+  english: I'm not very familiar with this problem.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 对
+    pinyin: duì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 来
+    pinyin: lái
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 不大
+    pinyin: bù dà
+  - chinese: 合适
+    pinyin: hé shì
+  - chinese: 。
+    pinyin: ''
+  english: This dress isn't quite suitable for me.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 声音
+    pinyin: shēng yīn
+  - chinese: 不大
+    pinyin: bù dà
+  - chinese: 好听
+    pinyin: hǎo tīng
+  - chinese: 。
+    pinyin: ''
+  english: His voice isn't very pleasant.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 对
+    pinyin: duì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 来
+    pinyin: lái
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 不大
+    pinyin: bù dà
+  - chinese: 多
+    pinyin: duō
+  - chinese: 难
+    pinyin: nán
+  - chinese: 。
+    pinyin: ''
+  english: This book isn't too difficult for me.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 事情
+    pinyin: shì qing
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不大
+    pinyin: bù dà
+  - chinese: 清楚
+    pinyin: qīng chu
+  - chinese: 。
+    pinyin: ''
+  english: I'm not quite clear about this matter.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 身高
+    pinyin: shēn gāo
+  - chinese: 不大
+    pinyin: bù dà
+  - chinese: 约
+    pinyin: yuē
+  - chinese: 莫
+    pinyin: mò
+  - chinese: 一
+    pinyin: yī
+  - chinese: 米
+    pinyin: mǐ
+  - chinese: 八
+    pinyin: bā
+  - chinese: 。
+    pinyin: ''
+  english: His height is not much, about one meter and eight.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 礼物
+    pinyin: lǐ wù
+  - chinese: 不大
+    pinyin: bù dà
+  - chinese: 多
+    pinyin: duō
+  - chinese: 贵
+    pinyin: guì
+  - chinese: 。
+    pinyin: ''
+  english: This gift isn't too expensive.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 答案
+    pinyin: dá àn
+  - chinese: 不对
+    pinyin: bù duì
+  - chinese: 。
+    pinyin: ''
+  english: Your answer is wrong.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 的
+    pinyin: de
+  - chinese: 不对
+    pinyin: bù duì
+  - chinese: 。
+    pinyin: ''
+  english: What you said is not correct.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 计算
+    pinyin: jì suàn
+  - chinese: 不对
+    pinyin: bù duì
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 再
+    pinyin: zài
+  - chinese: 检查
+    pinyin: jiǎn chá
+  - chinese: 一
+    pinyin: yī
+  - chinese: 遍
+    pinyin: biàn
+  - chinese: 。
+    pinyin: ''
+  english: This calculation is wrong, you need to check it again.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 这样
+    pinyin: zhè yàng
+  - chinese: 做
+    pinyin: zuò
+  - chinese: ，
+    pinyin: ''
+  - chinese: 这样
+    pinyin: zhè yàng
+  - chinese: 不对
+    pinyin: bù duì
+  - chinese: 。
+    pinyin: ''
+  english: You shouldn't do it like that, it's wrong.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 单词
+    pinyin: dān cí
+  - chinese: 拼错
+    pinyin: pīn cuò
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不对
+    pinyin: bù duì
+  - chinese: 。
+    pinyin: ''
+  english: You spelled this word incorrectly, that's wrong.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 行为
+    pinyin: xíng wéi
+  - chinese: 不对
+    pinyin: bù duì
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 道歉
+    pinyin: dào qiàn
+  - chinese: 。
+    pinyin: ''
+  english: Your behavior is wrong, you should apologize.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 这样
+    pinyin: zhè yàng
+  - chinese: 说
+    pinyin: shuō
+  - chinese: ，
+    pinyin: ''
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 不对
+    pinyin: bù duì
+  - chinese: 。
+    pinyin: ''
+  english: You shouldn't say it like that, it's not right.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 打球
+    pinyin: dǎ qiú
+  - chinese: 。
+    pinyin: ''
+  english: I like playing ball games.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 下午
+    pinyin: xià wǔ
+  - chinese: 打球
+    pinyin: dǎ qiú
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 来
+    pinyin: lái
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: We're playing ball tomorrow afternoon, do you want to join?
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 每
+    pinyin: měi
+  - chinese: 周末
+    pinyin: zhōu mò
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 去
+    pinyin: qù
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 打球
+    pinyin: dǎ qiú
+  - chinese: 。
+    pinyin: ''
+  english: They go to the park to play ball every weekend.
+
+- segments:
+  - chinese: 打球
+    pinyin: dǎ qiú
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 要
+    pinyin: yào
+  - chinese: 注意
+    pinyin: zhù yì
+  - chinese: 安全
+    pinyin: ān quán
+  - chinese: 。
+    pinyin: ''
+  english: Be careful and pay attention to safety when playing ball games.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 干什么
+    pinyin: gàn shén me
+  - chinese: ？
+    pinyin: ''
+  english: What are you doing?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 干什么
+    pinyin: gàn shén me
+  - chinese: 呢
+    pinyin: ne
+  - chinese: ？
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 作业
+    pinyin: zuò yè
+  - chinese: 。
+    pinyin: ''
+  english: What are you up to? I'm doing homework.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 干什么
+    pinyin: gàn shén me
+  - chinese: 呢
+    pinyin: ne
+  - chinese: ？
+    pinyin: ''
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 不
+    pinyin: bù
+  - chinese: 回答
+    pinyin: huí dá
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: ？
+    pinyin: ''
+  english: What are you doing? Why aren't you answering me?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 干什么
+    pinyin: gàn shén me
+  - chinese: 呢
+    pinyin: ne
+  - chinese: ？
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 帮忙
+    pinyin: bāng máng
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: What are you up to? Can I help?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 干什么
+    pinyin: gàn shén me
+  - chinese: ，
+    pinyin: ''
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 不
+    pinyin: bù
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 建议
+    pinyin: jiàn yì
+  - chinese: ？
+    pinyin: ''
+  english: What are you doing? Why aren't you taking my advice?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 干什么
+    pinyin: gàn shén me
+  - chinese: 啊
+    pinyin: a
+  - chinese: ？
+    pinyin: ''
+  - chinese: 别
+    pinyin: bié
+  - chinese: 浪费
+    pinyin: làng fèi
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 了
+    pinyin: le
+  - chinese: ！
+    pinyin: ''
+  english: What are you doing? Stop wasting time!
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 干什么
+    pinyin: gàn shén me
+  - chinese: ，
+    pinyin: ''
+  - chinese: 快
+    pinyin: kuài
+  - chinese: 停
+    pinyin: tíng
+  - chinese: 下来
+    pinyin: xià lai
+  - chinese: ！
+    pinyin: ''
+  english: What are you doing, stop immediately!
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 茶
+    pinyin: chá
+  - chinese: 还是
+    pinyin: hái shi
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: ？
+    pinyin: ''
+  english: Tea or coffee?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 是
+    pinyin: shì
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 还是
+    pinyin: hái shi
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: ？
+    pinyin: ''
+  english: Are you a teacher or a student?
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 还是
+    pinyin: hái shi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 年轻
+    pinyin: nián qīng
+  - chinese: 。
+    pinyin: ''
+  english: She is still very young.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 还是
+    pinyin: hái shi
+  - chinese: 没
+    pinyin: méi
+  - chinese: 离婚
+    pinyin: lí hūn
+  - chinese: 。
+    pinyin: ''
+  english: They still haven't gotten divorced.
+
+- segments:
+  - chinese: 还是
+    pinyin: hái shi
+  - chinese: 老
+    pinyin: lǎo
+  - chinese: 地方
+    pinyin: dì fang
+  - chinese: 见
+    pinyin: jiàn
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Let's meet at the usual place.
+
+- segments:
+  - chinese: 还是
+    pinyin: hái shi
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 同样
+    pinyin: tóng yàng
+  - chinese: 的
+    pinyin: de
+  - chinese: 酒
+    pinyin: jiǔ
+  - chinese: 。
+    pinyin: ''
+  english: Let's drink the same wine as before.
+
+- segments:
+  - chinese: 还是
+    pinyin: hái shi
+  - chinese: 保持
+    pinyin: bǎo chí
+  - chinese: 同样
+    pinyin: tóng yàng
+  - chinese: 的
+    pinyin: de
+  - chinese: 价格
+    pinyin: jià gé
+  - chinese: 。
+    pinyin: ''
+  english: Let's keep the price the same as before.
+
+- segments:
+  - chinese: 还有
+    pinyin: hái yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: 才
+    pinyin: cái
+  - chinese: 到
+    pinyin: dào
+  - chinese: 中午
+    pinyin: zhōng wǔ
+  - chinese: 。
+    pinyin: ''
+  english: There's still an hour until noon.
+
+- segments:
+  - chinese: 还有
+    pinyin: hái yǒu
+  - chinese: 别
+    pinyin: bié
+  - chinese: 的
+    pinyin: de
+  - chinese: 选择
+    pinyin: xuǎn zé
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Are there any other choices?
+
+- segments:
+  - chinese: 还有
+    pinyin: hái yǒu
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 天
+    pinyin: tiān
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 周末
+    pinyin: zhōu mò
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 期待
+    pinyin: qī dài
+  - chinese: 。
+    pinyin: ''
+  english: There are still two days until the weekend, I'm looking forward to it.
+
+- segments:
+  - chinese: 还有
+    pinyin: hái yǒu
+  - chinese: 别
+    pinyin: bié
+  - chinese: 的
+    pinyin: de
+  - chinese: 颜色
+    pinyin: yán sè
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想要
+    pinyin: xiǎng yào
+  - chinese: 蓝色
+    pinyin: lán sè
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: Are there any other colors? I want something blue.
+
+- segments:
+  - chinese: 还有
+    pinyin: hái yǒu
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 的
+    pinyin: de
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Is there anything else that needs to be prepared?
+
+- segments:
+  - chinese: 还有
+    pinyin: hái yǒu
+  - chinese: 谁
+    pinyin: shéi
+  - chinese: 还
+    pinyin: hái
+  - chinese: 没
+    pinyin: méi
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 午饭
+    pinyin: wǔ fàn
+  - chinese: ？
+    pinyin: ''
+  english: Is there anyone else who hasn't eaten lunch?
+
+- segments:
+  - chinese: 还有
+    pinyin: hái yǒu
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Are there any other questions?
+
+- segments:
+  - chinese: 还有
+    pinyin: hái yǒu
+  - chinese: 别
+    pinyin: bié
+  - chinese: 的
+    pinyin: de
+  - chinese: 交通
+    pinyin: jiāo tōng
+  - chinese: 方式
+    pinyin: fāng shì
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Are there any other means of transportation?
+
+- segments:
+  - chinese: 还有
+    pinyin: hái yǒu
+  - chinese: 谁
+    pinyin: shéi
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 交
+    pinyin: jiāo
+  - chinese: 作业
+    pinyin: zuò yè
+  - chinese: ？
+    pinyin: ''
+  english: Who else hasn't turned in their homework?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 成绩
+    pinyin: chéng jì
+  - chinese: 是
+    pinyin: shì
+  - chinese: 零
+    pinyin: líng
+  - chinese: 分
+    pinyin: fēn
+  - chinese: 。
+    pinyin: ''
+  english: My score is zero.
+
+- segments:
+  - chinese: 室外
+    pinyin: shì wài
+  - chinese: 温度
+    pinyin: wēn dù
+  - chinese: 零下
+    pinyin: líng xià
+  - chinese: 十
+    pinyin: shí
+  - chinese: 度
+    pinyin: dù
+  - chinese: 。
+    pinyin: ''
+  english: The outdoor temperature is ten degrees below zero.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 产品
+    pinyin: chǎn pǐn
+  - chinese: 不
+    pinyin: bù
+  - chinese: 含
+    pinyin: hán
+  - chinese: 任何
+    pinyin: rèn hé
+  - chinese: 添加剂
+    pinyin: tiān jiā jì
+  - chinese: ，
+    pinyin: ''
+  - chinese: 是
+    pinyin: shì
+  - chinese: 零
+    pinyin: líng
+  - chinese: 添加剂
+    pinyin: tiān jiā jì
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: This product contains no additives, it's additive-free.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 这里
+    pinyin: zhè lǐ
+  - chinese: 找到
+    pinyin: zhǎo dào
+  - chinese: 零
+    pinyin: líng
+  - chinese: 污染
+    pinyin: wū rǎn
+  - chinese: 的
+    pinyin: de
+  - chinese: 空气
+    pinyin: kōng qì
+  - chinese: 。
+    pinyin: ''
+  english: You can find pollution-free air here.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 餐厅
+    pinyin: cān tīng
+  - chinese: 提供
+    pinyin: tí gōng
+  - chinese: 零
+    pinyin: líng
+  - chinese: 脂肪
+    pinyin: zhī fáng
+  - chinese: 的
+    pinyin: de
+  - chinese: 餐饮
+    pinyin: cān yǐn
+  - chinese: 选择
+    pinyin: xuǎn zé
+  - chinese: 。
+    pinyin: ''
+  english: This restaurant offers fat-free dining options.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 地区
+    pinyin: dì qū
+  - chinese: 是
+    pinyin: shì
+  - chinese: 零
+    pinyin: líng
+  - chinese: 犯罪
+    pinyin: fàn zuì
+  - chinese: 率
+    pinyin: lǜ
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: This area has a zero crime rate.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 楼
+    pinyin: lóu
+  - chinese: 的
+    pinyin: de
+  - chinese: 工作室
+    pinyin: gōng zuò shì
+  - chinese: 会面
+    pinyin: huì miàn
+  - chinese: 。
+    pinyin: ''
+  english: Let's meet at our studio on the fifth floor.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 住
+    pinyin: zhù
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 楼
+    pinyin: lóu
+  - chinese: ？
+    pinyin: ''
+  english: Which floor do you live on?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 在
+    pinyin: zài
+  - chinese: 二
+    pinyin: èr
+  - chinese: 楼
+    pinyin: lóu
+  - chinese: 。
+    pinyin: ''
+  english: My room is on the second floor.
+
+- segments:
+  - chinese: 楼上
+    pinyin: lóu shàng
+  - chinese: 的
+    pinyin: de
+  - chinese: 邻居
+    pinyin: lín jū
+  - chinese: 太
+    pinyin: tài
+  - chinese: 吵
+    pinyin: chǎo
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: The upstairs neighbors are too noisy.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 包
+    pinyin: bāo
+  - chinese: 落
+    pinyin: luò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 楼上
+    pinyin: lóu shàng
+  - chinese: 了
+    pinyin: le
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Did you leave your bag upstairs?
+
+- segments:
+  - chinese: 楼上
+    pinyin: lóu shàng
+  - chinese: 的
+    pinyin: de
+  - chinese: 人
+    pinyin: rén
+  - chinese: 能
+    pinyin: néng
+  - chinese: 听到
+    pinyin: tīng dào
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 的
+    pinyin: de
+  - chinese: 声音
+    pinyin: shēng yīn
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can the people upstairs hear our voices?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 办公室
+    pinyin: bàn gōng shì
+  - chinese: 在
+    pinyin: zài
+  - chinese: 楼下
+    pinyin: lóu xià
+  - chinese: 。
+    pinyin: ''
+  english: My office is downstairs.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 楼下
+    pinyin: lóu xià
+  - chinese: 等
+    pinyin: děng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 别
+    pinyin: bié
+  - chinese: 赶
+    pinyin: gǎn
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 。
+    pinyin: ''
+  english: I'll wait for you downstairs, take your time.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 路口
+    pinyin: lù kǒu
+  - chinese: 停下来
+    pinyin: tíng xià lái
+  - chinese: ，
+    pinyin: ''
+  - chinese: 等
+    pinyin: děng
+  - chinese: 待
+    pinyin: dài
+  - chinese: 绿
+    pinyin: lǜ
+  - chinese: 灯
+    pinyin: dēng
+  - chinese: 。
+    pinyin: ''
+  english: I stopped at the intersection and waited for the green light.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 条
+    pinyin: tiáo
+  - chinese: 路
+    pinyin: lù
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 繁忙
+    pinyin: fán máng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 所以
+    pinyin: suǒ yǐ
+  - chinese: 路口
+    pinyin: lù kǒu
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 会
+    pinyin: huì
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 交通
+    pinyin: jiāo tōng
+  - chinese: 。
+    pinyin: ''
+  english: This road is very busy, so there is usually a lot of traffic at the junction.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 下
+    pinyin: xià
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 路口
+    pinyin: lù kǒu
+  - chinese: 左转
+    pinyin: zuǒ zhuǎn
+  - chinese: 。
+    pinyin: ''
+  english: You can turn left at the next intersection.
+
+- segments:
+  - chinese: 路口
+    pinyin: lù kǒu
+  - chinese: 发生
+    pinyin: fā shēng
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 起
+    pinyin: qǐ
+  - chinese: 车祸
+    pinyin: chē huò
+  - chinese: ，
+    pinyin: ''
+  - chinese: 导致
+    pinyin: dǎo zhì
+  - chinese: 交通
+    pinyin: jiāo tōng
+  - chinese: 堵塞
+    pinyin: dǔ sè
+  - chinese: 。
+    pinyin: ''
+  english: A car accident occurred at the intersection, causing a traffic jam.
+
+- segments:
+  - chinese: 路口
+    pinyin: lù kǒu
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 红
+    pinyin: hóng
+  - chinese: 绿
+    pinyin: lǜ
+  - chinese: 灯
+    pinyin: dēng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 用来
+    pinyin: yòng lái
+  - chinese: 控制
+    pinyin: kòng zhì
+  - chinese: 车流
+    pinyin: chē liú
+  - chinese: 的
+    pinyin: de
+  - chinese: 通行
+    pinyin: tōng xíng
+  - chinese: 。
+    pinyin: ''
+  english: There is a traffic light at the intersection to control the flow of vehicles.
+
+- segments:
+  - chinese: 马路
+    pinyin: mǎ lù
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 宽
+    pinyin: kuān
+  - chinese: 。
+    pinyin: ''
+  english: The road is very wide.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 条
+    pinyin: tiáo
+  - chinese: 马路
+    pinyin: mǎ lù
+  - chinese: 两边
+    pinyin: liǎng biān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 树
+    pinyin: shù
+  - chinese: 。
+    pinyin: ''
+  english: There are trees on both sides of this street.
+
+- segments:
+  - chinese: 过
+    pinyin: guò
+  - chinese: 马路
+    pinyin: mǎ lù
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 要
+    pinyin: yào
+  - chinese: 小心
+    pinyin: xiǎo xīn
+  - chinese: 车
+    pinyin: chē
+  - chinese: 。
+    pinyin: ''
+  english: Be careful of cars when crossing the road.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 沿着
+    pinyin: yán zhe
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 条
+    pinyin: tiáo
+  - chinese: 马路
+    pinyin: mǎ lù
+  - chinese: 跑步
+    pinyin: pǎo bù
+  - chinese: 。
+    pinyin: ''
+  english: I jog along this street every day.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 次
+    pinyin: cì
+  - chinese: 考试
+    pinyin: kǎo shì
+  - chinese: 没什么
+    pinyin: méi shén me
+  - chinese: 困难
+    pinyin: kùn nan
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: This exam isn't very difficult.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 没什么
+    pinyin: méi shén me
+  - chinese: 经验
+    pinyin: jīng yàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 所以
+    pinyin: suǒ yǐ
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 要
+    pinyin: yào
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 他
+    pinyin: tā
+  - chinese: 。
+    pinyin: ''
+  english: He doesn't have much experience, so we should help him.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 别
+    pinyin: bié
+  - chinese: 担心
+    pinyin: dān xīn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 事
+    pinyin: shì
+  - chinese: 没什么
+    pinyin: méi shén me
+  - chinese: 。
+    pinyin: ''
+  english: Don't worry about it, it's not a big deal.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 没什么
+    pinyin: méi shén me
+  - chinese: 计划
+    pinyin: jì huà
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 随便
+    pinyin: suí biàn
+  - chinese: 逛逛
+    pinyin: guàng guang
+  - chinese: 街
+    pinyin: jiē
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: We don't have any plans today, let's just casually stroll the streets.
+
+- segments:
+  - chinese: 别
+    pinyin: bié
+  - chinese: 担心
+    pinyin: dān xīn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 没事儿
+    pinyin: méi shì r
+  - chinese: 。
+    pinyin: ''
+  english: Don't worry, I'm fine.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 说
+    pinyin: shuō
+  - chinese: ，
+    pinyin: ''
+  - chinese: 没事儿
+    pinyin: méi shì r
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: Feel free to say whatever you want, it doesn't matter.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 门口
+    pinyin: mén kǒu
+  - chinese: 等
+    pinyin: děng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 。
+    pinyin: ''
+  english: He waited for me at the entrance of the store.
+
+- segments:
+  - chinese: 医院
+    pinyin: yī yuàn
+  - chinese: 门口
+    pinyin: mén kǒu
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 群
+    pinyin: qún
+  - chinese: 记者
+    pinyin: jì zhě
+  - chinese: 。
+    pinyin: ''
+  english: There was a group of journalists at the hospital entrance.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 门口
+    pinyin: mén kǒu
+  - chinese: 迎宾
+    pinyin: yíng bīn
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Are you greeting guests at the door?
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 站
+    pinyin: zhàn
+  - chinese: 在
+    pinyin: zài
+  - chinese: 教室
+    pinyin: jiào shì
+  - chinese: 门口
+    pinyin: mén kǒu
+  - chinese: 交谈
+    pinyin: jiāo tán
+  - chinese: 。
+    pinyin: ''
+  english: They stood at the classroom doorway talking.
+
+- segments:
+  - chinese: 博物馆
+    pinyin: bó wù guǎn
+  - chinese: 门口
+    pinyin: mén kǒu
+  - chinese: 排
+    pinyin: pái
+  - chinese: 了
+    pinyin: le
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 长
+    pinyin: cháng
+  - chinese: 的
+    pinyin: de
+  - chinese: 队
+    pinyin: duì
+  - chinese: 。
+    pinyin: ''
+  english: There was a long line at the entrance of the museum.
+
+- segments:
+  - chinese: 音乐会
+    pinyin: yīn yuè huì
+  - chinese: 门票
+    pinyin: mén piào
+  - chinese: 在
+    pinyin: zài
+  - chinese: 网
+    pinyin: wǎng
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 卖
+    pinyin: mài
+  - chinese: 得
+    pinyin: de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 火
+    pinyin: huǒ
+  - chinese: 。
+    pinyin: ''
+  english: The concert tickets are selling like hotcakes online.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 球赛
+    pinyin: qiú sài
+  - chinese: 的
+    pinyin: de
+  - chinese: 门票
+    pinyin: mén piào
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 多
+    pinyin: duō
+  - chinese: 要
+    pinyin: yào
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 。
+    pinyin: ''
+  english: Do you have any tickets for the ball game? I'd like to get a few more.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 博物馆
+    pinyin: bó wù guǎn
+  - chinese: 周
+    pinyin: zhōu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 免费
+    pinyin: miǎn fèi
+  - chinese: 开放
+    pinyin: kāi fàng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不
+    pinyin: bù
+  - chinese: 用
+    pinyin: yòng
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 门票
+    pinyin: mén piào
+  - chinese: 。
+    pinyin: ''
+  english: This museum is free of charge on Mondays, so you don't need to buy tickets.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 音乐会
+    pinyin: yīn yuè huì
+  - chinese: 门票
+    pinyin: mén piào
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 贵
+    pinyin: guì
+  - chinese: 。
+    pinyin: ''
+  english: This concert ticket is expensive.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 去
+    pinyin: qù
+  - chinese: 主题
+    pinyin: zhǔ tí
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 的
+    pinyin: de
+  - chinese: 门票
+    pinyin: mén piào
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Have you bought the tickets for the theme park?
+
+- segments:
+  - chinese: 博物馆
+    pinyin: bó wù guǎn
+  - chinese: 的
+    pinyin: de
+  - chinese: 门票
+    pinyin: mén piào
+  - chinese: 已
+    pinyin: yǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 线上
+    pinyin: xiàn shàng
+  - chinese: 售完
+    pinyin: shòu wán
+  - chinese: 。
+    pinyin: ''
+  english: The museum tickets are already sold out online.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 这儿
+    pinyin: zhè r
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 到
+    pinyin: dào
+  - chinese: 戏院
+    pinyin: xì yuàn
+  - chinese: 的
+    pinyin: de
+  - chinese: 门票
+    pinyin: mén piào
+  - chinese: 。
+    pinyin: ''
+  english: You can buy tickets for the theater here.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 到
+    pinyin: dào
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 部
+    pinyin: bù
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 的
+    pinyin: de
+  - chinese: 门票
+    pinyin: mén piào
+  - chinese: ？
+    pinyin: ''
+  english: Where can I buy tickets to this movie?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 部
+    pinyin: bù
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 的
+    pinyin: de
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 门票
+    pinyin: mén piào
+  - chinese: 。
+    pinyin: ''
+  english: I have two tickets for these two movies.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 多少
+    pinyin: duō shao
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 门票
+    pinyin: mén piào
+  - chinese: ？
+    pinyin: ''
+  english: How many tickets did you buy?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 次
+    pinyin: cì
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 部
+    pinyin: bù
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 的
+    pinyin: de
+  - chinese: 门票
+    pinyin: mén piào
+  - chinese: ？
+    pinyin: ''
+  english: How many times did you buy tickets for this movie?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 面条儿
+    pinyin: miàn tiáo r
+  - chinese: 。
+    pinyin: ''
+  english: I like to eat noodles.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 碗
+    pinyin: wǎn
+  - chinese: 面条儿
+    pinyin: miàn tiáo r
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 热
+    pinyin: rè
+  - chinese: 。
+    pinyin: ''
+  english: These noodles are very hot.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 常
+    pinyin: cháng
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 面条儿
+    pinyin: miàn tiáo r
+  - chinese: 和
+    pinyin: hé
+  - chinese: 米饭
+    pinyin: mǐ fàn
+  - chinese: 。
+    pinyin: ''
+  english: I often eat noodles and rice.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 面条儿
+    pinyin: miàn tiáo r
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you eat noodles every day?
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 男孩儿
+    pinyin: nán hái r
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 帅
+    pinyin: shuài
+  - chinese: 。
+    pinyin: ''
+  english: That boy is very handsome.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 男孩儿
+    pinyin: nán hái r
+  - chinese: 。
+    pinyin: ''
+  english: I have two boys.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 男孩儿
+    pinyin: nán hái r
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 聪明
+    pinyin: cōng ming
+  - chinese: 。
+    pinyin: ''
+  english: That boy is very smart.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 认识
+    pinyin: rèn shi
+  - chinese: 那
+    pinyin: nà
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 男孩儿
+    pinyin: nán hái r
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you know those two boys?
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 男孩儿
+    pinyin: nán hái r
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 踢
+    pinyin: tī
+  - chinese: 足球
+    pinyin: zú qiú
+  - chinese: 。
+    pinyin: ''
+  english: That boy likes playing soccer a lot.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 男生
+    pinyin: nán shēng
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 上学
+    pinyin: shàng xué
+  - chinese: 。
+    pinyin: ''
+  english: I go to school with that boy.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 男生
+    pinyin: nán shēng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 聪明
+    pinyin: cōng ming
+  - chinese: 。
+    pinyin: ''
+  english: That schoolboy is very smart.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 男生
+    pinyin: nán shēng
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you like that schoolboy?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 介绍
+    pinyin: jiè shào
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 哥哥
+    pinyin: gē ge
+  - chinese: ，
+    pinyin: ''
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 酷
+    pinyin: kù
+  - chinese: 的
+    pinyin: de
+  - chinese: 男生
+    pinyin: nán shēng
+  - chinese: 。
+    pinyin: ''
+  english: I want to introduce you to my brother. He's a very cool guy.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 班上
+    pinyin: bān shàng
+  - chinese: 大多数
+    pinyin: dà duō shù
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 是
+    pinyin: shì
+  - chinese: 男生
+    pinyin: nán shēng
+  - chinese: 。
+    pinyin: ''
+  english: Most of the students in this class are boys.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 男
+    pinyin: nán
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: He is male.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 三
+    pinyin: sān
+  - chinese: 个
+    pinyin: gè
+  - chinese: 男
+    pinyin: nán
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: There are three males in our family.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 男
+    pinyin: nán
+  - chinese: 的
+    pinyin: de
+  - chinese: 来
+    pinyin: lái
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 。
+    pinyin: ''
+  english: This job requires a male to do it.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 男
+    pinyin: nán
+  - chinese: 的
+    pinyin: de
+  - chinese: 演员
+    pinyin: yǎn yuán
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有名
+    pinyin: yǒu míng
+  - chinese: 。
+    pinyin: ''
+  english: This male actor is very famous.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 房子
+    pinyin: fáng zi
+  - chinese: 在
+    pinyin: zài
+  - chinese: 南边
+    pinyin: nán bian
+  - chinese: 。
+    pinyin: ''
+  english: My house is in the south.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 南边
+    pinyin: nán bian
+  - chinese: 等
+    pinyin: děng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 。
+    pinyin: ''
+  english: We are waiting for you in the south.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 向
+    pinyin: xiàng
+  - chinese: 南边
+    pinyin: nán bian
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 街区
+    pinyin: jiē qū
+  - chinese: 。
+    pinyin: ''
+  english: You can walk two blocks south.
+
+- segments:
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 的
+    pinyin: de
+  - chinese: 南边
+    pinyin: nán bian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 湖
+    pinyin: hú
+  - chinese: 。
+    pinyin: ''
+  english: There's a lake on the south side of the park.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 南边
+    pinyin: nán bian
+  - chinese: 的
+    pinyin: de
+  - chinese: 餐厅
+    pinyin: cān tīng
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: 。
+    pinyin: ''
+  english: We're having dinner at a restaurant in the south.
+
+- segments:
+  - chinese: 北京
+    pinyin: Běi jīng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 南
+    pinyin: nán
+  - chinese: ，
+    pinyin: ''
+  - chinese: 上海
+    pinyin: Shàng hǎi
+  - chinese: 在
+    pinyin: zài
+  - chinese: 东
+    pinyin: dōng
+  - chinese: 。
+    pinyin: ''
+  english: Beijing is in the south, Shanghai is in the east.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 向
+    pinyin: xiàng
+  - chinese: 南
+    pinyin: nán
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 。
+    pinyin: ''
+  english: We are heading south.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 女孩儿
+    pinyin: nǚ hái r
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 。
+    pinyin: ''
+  english: That girl is very pretty.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 三
+    pinyin: sān
+  - chinese: 个
+    pinyin: gè
+  - chinese: 女孩儿
+    pinyin: nǚ hái r
+  - chinese: 。
+    pinyin: ''
+  english: I have three girls.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 女孩儿
+    pinyin: nǚ hái r
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 聪明
+    pinyin: cōng ming
+  - chinese: 。
+    pinyin: ''
+  english: That girl is very smart.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 认识
+    pinyin: rèn shi
+  - chinese: 那
+    pinyin: nà
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 女孩儿
+    pinyin: nǚ hái r
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you know those two girls?
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 女孩儿
+    pinyin: nǚ hái r
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 唱歌
+    pinyin: chàng gē
+  - chinese: 。
+    pinyin: ''
+  english: That girl likes singing a lot.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 女朋友
+    pinyin: nǚ péng you
+  - chinese: 。
+    pinyin: ''
+  english: She is my girlfriend.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 会
+    pinyin: huì
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 女朋友
+    pinyin: nǚ péng you
+  - chinese: ？
+    pinyin: ''
+  english: When will you have a girlfriend?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 女朋友
+    pinyin: nǚ péng you
+  - chinese: 分手
+    pinyin: fēn shǒu
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I broke up with my girlfriend.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 女朋友
+    pinyin: nǚ péng you
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪儿
+    pinyin: nǎ r
+  - chinese: ？
+    pinyin: ''
+  english: Where is your girlfriend?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 女朋友
+    pinyin: nǚ péng you
+  - chinese: 已经
+    pinyin: yǐ jīng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 年
+    pinyin: nián
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: My girlfriend and I have been together for two years.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 女生
+    pinyin: nǚ shēng
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 上学
+    pinyin: shàng xué
+  - chinese: 。
+    pinyin: ''
+  english: I go to school with that girl.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 女生
+    pinyin: nǚ shēng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 聪明
+    pinyin: cōng ming
+  - chinese: 。
+    pinyin: ''
+  english: That girl is very smart.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 女生
+    pinyin: nǚ shēng
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you like that girl?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 房子
+    pinyin: fáng zi
+  - chinese: 在
+    pinyin: zài
+  - chinese: 前边
+    pinyin: qián bian
+  - chinese: 。
+    pinyin: ''
+  english: My house is in front.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 那
+    pinyin: nà
+  - chinese: 棵
+    pinyin: kē
+  - chinese: 大
+    pinyin: dà
+  - chinese: 树
+    pinyin: shù
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 车
+    pinyin: chē
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 停
+    pinyin: tíng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 它
+    pinyin: tā
+  - chinese: 前边
+    pinyin: qián bian
+  - chinese: 。
+    pinyin: ''
+  english: See that big tree? My car is parked right in front of it.
+
+- segments:
+  - chinese: 排
+    pinyin: pái
+  - chinese: 在
+    pinyin: zài
+  - chinese: 前边
+    pinyin: qián bian
+  - chinese: 的
+    pinyin: de
+  - chinese: 人
+    pinyin: rén
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 先
+    pinyin: xiān
+  - chinese: 入场
+    pinyin: rù chǎng
+  - chinese: 。
+    pinyin: ''
+  english: Those in front can enter first.
+
+- segments:
+  - chinese: 火车
+    pinyin: huǒ chē
+  - chinese: 的
+    pinyin: de
+  - chinese: 前边
+    pinyin: qián bian
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 节
+    pinyin: jiē
+  - chinese: 车厢
+    pinyin: chē xiāng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 空
+    pinyin: kōng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 那里
+    pinyin: nà li
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 。
+    pinyin: ''
+  english: The first few train compartments in front are empty; you can go sit there.
+
+- segments:
+  - chinese: 注意
+    pinyin: zhù yì
+  - chinese: 前边
+    pinyin: qián bian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 台阶
+    pinyin: tái jiē
+  - chinese: ，
+    pinyin: ''
+  - chinese: 别
+    pinyin: bié
+  - chinese: 踩空
+    pinyin: cǎi kōng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: Watch out for the step in front; don't miss your step.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 前天
+    pinyin: qián tiān
+  - chinese: 去
+    pinyin: qù
+  - chinese: 了
+    pinyin: le
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 。
+    pinyin: ''
+  english: I went to the park the day before yesterday.
+
+- segments:
+  - chinese: 前天
+    pinyin: qián tiān
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: The weather was very nice the day before yesterday.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 前天
+    pinyin: qián tiān
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 没
+    pinyin: méi
+  - chinese: 来
+    pinyin: lái
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 课
+    pinyin: kè
+  - chinese: ？
+    pinyin: ''
+  english: Why weren't you in class the day before yesterday?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 前天
+    pinyin: qián tiān
+  - chinese: 收到
+    pinyin: shōu dào
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 消息
+    pinyin: xiāo xi
+  - chinese: 。
+    pinyin: ''
+  english: I received some good news the day before yesterday.
+
+- segments:
+  - chinese: 记得
+    pinyin: jì de
+  - chinese: 前天
+    pinyin: qián tiān
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 讨论
+    pinyin: tǎo lùn
+  - chinese: 的
+    pinyin: de
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you remember the issue we discussed the day before yesterday?
+
+- segments:
+  - chinese: 请进
+    pinyin: qǐng jìn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 别客气
+    pinyin: bié kè qi
+  - chinese: 。
+    pinyin: ''
+  english: Please come in, don't be shy.
+
+- segments:
+  - chinese: 欢迎
+    pinyin: huān yíng
+  - chinese: 光临
+    pinyin: guāng lín
+  - chinese: ，
+    pinyin: ''
+  - chinese: 请进
+    pinyin: qǐng jìn
+  - chinese: ！
+    pinyin: ''
+  english: Welcome! Please come in!
+
+- segments:
+  - chinese: 门
+    pinyin: mén
+  - chinese: 开
+    pinyin: kāi
+  - chinese: 着
+    pinyin: zhe
+  - chinese: ，
+    pinyin: ''
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 进来
+    pinyin: jìn lái
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 。
+    pinyin: ''
+  english: The door is open, please come in and sit down.
+
+- segments:
+  - chinese: 考试
+    pinyin: kǎo shì
+  - chinese: 开始
+    pinyin: kāi shǐ
+  - chinese: 啦
+    pinyin: la
+  - chinese: ，
+    pinyin: ''
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 们
+    pinyin: men
+  - chinese: ，
+    pinyin: ''
+  - chinese: 请进
+    pinyin: qǐng jìn
+  - chinese: 。
+    pinyin: ''
+  english: The exam is starting, students, please come in.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: ，
+    pinyin: ''
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 进来
+    pinyin: jìn lái
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 正
+    pinyin: zhèng
+  - chinese: 有事
+    pinyin: yǒu shì
+  - chinese: 找
+    pinyin: zhǎo
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 。
+    pinyin: ''
+  english: Hello, please come in. I was just looking for you.
+
+- segments:
+  - chinese: 请坐
+    pinyin: qǐng zuò
+  - chinese: ，
+    pinyin: ''
+  - chinese: 别
+    pinyin: bié
+  - chinese: 客气
+    pinyin: kè qi
+  - chinese: 。
+    pinyin: ''
+  english: Please sit down, don't be shy.
+
+- segments:
+  - chinese: 这里
+    pinyin: zhè lǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 空位
+    pinyin: kōng wèi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 请坐
+    pinyin: qǐng zuò
+  - chinese: 。
+    pinyin: ''
+  english: There is a vacant seat here, please sit down.
+
+- segments:
+  - chinese: 您
+    pinyin: nín
+  - chinese: 慢
+    pinyin: màn
+  - chinese: 吃
+    pinyin: chī
+  - chinese: ，
+    pinyin: ''
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 坐下
+    pinyin: zuò xia
+  - chinese: 聊
+    pinyin: liáo
+  - chinese: 聊
+    pinyin: liáo
+  - chinese: 。
+    pinyin: ''
+  english: Take your time with your meal, please sit down and let's chat.
+
+- segments:
+  - chinese: 会议
+    pinyin: huì yì
+  - chinese: 马上
+    pinyin: mǎ shàng
+  - chinese: 开始
+    pinyin: kāi shǐ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 大家
+    pinyin: dà jiā
+  - chinese: 请坐
+    pinyin: qǐng zuò
+  - chinese: 。
+    pinyin: ''
+  english: The meeting will begin shortly, everyone please be seated.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: ，
+    pinyin: ''
+  - chinese: 请坐
+    pinyin: qǐng zuò
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 拿
+    pinyin: ná
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 。
+    pinyin: ''
+  english: Hello, please sit down. I'll get you a glass of water.
+
+- segments:
+  - chinese: 书架
+    pinyin: shū jià
+  - chinese: 的
+    pinyin: de
+  - chinese: 上边
+    pinyin: shàng bian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: There are several books on the upper part of the bookshelf.
+
+- segments:
+  - chinese: 天上
+    pinyin: tiān shàng
+  - chinese: 是不是
+    pinyin: shì bù shì
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 云
+    pinyin: yún
+  - chinese: 在
+    pinyin: zài
+  - chinese: 上面
+    pinyin: shàng miàn
+  - chinese: 飘
+    pinyin: piāo
+  - chinese: ？
+    pinyin: ''
+  english: Are there clouds drifting above in the sky?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 的
+    pinyin: de
+  - chinese: 上边
+    pinyin: shàng bian
+  - chinese: 有点
+    pinyin: yǒu diǎn
+  - chinese: 脏
+    pinyin: zāng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 擦
+    pinyin: cā
+  - chinese: 一下
+    pinyin: yī xià
+  - chinese: 。
+    pinyin: ''
+  english: The upper surface of this table is a bit dirty and needs to be wiped.
+
+- segments:
+  - chinese: 鸟
+    pinyin: niǎo
+  - chinese: 在
+    pinyin: zài
+  - chinese: 天空
+    pinyin: tiān kōng
+  - chinese: 的
+    pinyin: de
+  - chinese: 上边
+    pinyin: shàng bian
+  - chinese: 自由
+    pinyin: zì yóu
+  - chinese: 地
+    pinyin: de
+  - chinese: 飞翔
+    pinyin: fēi xiáng
+  - chinese: 。
+    pinyin: ''
+  english: Birds fly freely above in the sky.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 箱子
+    pinyin: xiāng zi
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 上边
+    pinyin: shàng bian
+  - chinese: 。
+    pinyin: ''
+  english: You can put this box on top of the table.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 房子
+    pinyin: fáng zi
+  - chinese: 在
+    pinyin: zài
+  - chinese: 西边
+    pinyin: xī biān
+  - chinese: 。
+    pinyin: ''
+  english: My house is on the west side.
+
+- segments:
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 在
+    pinyin: zài
+  - chinese: 西边
+    pinyin: xī biān
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不能
+    pinyin: bù néng
+  - chinese: 错过
+    pinyin: cuò guò
+  - chinese: 它
+    pinyin: tā
+  - chinese: 。
+    pinyin: ''
+  english: The school is on the west side; you can't miss it.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 西边
+    pinyin: xī biān
+  - chinese: 的
+    pinyin: de
+  - chinese: 大
+    pinyin: dà
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 得
+    pinyin: de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 开心
+    pinyin: kāi xīn
+  - chinese: 。
+    pinyin: ''
+  english: We had a great time at the large park on the west side.
+
+- segments:
+  - chinese: 太阳
+    pinyin: tài yang
+  - chinese: 落
+    pinyin: luò
+  - chinese: 山
+    pinyin: shān
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 天空
+    pinyin: tiān kōng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 西边
+    pinyin: xī biān
+  - chinese: 呈现
+    pinyin: chéng xiàn
+  - chinese: 出
+    pinyin: chū
+  - chinese: 美丽
+    pinyin: měi lì
+  - chinese: 的
+    pinyin: de
+  - chinese: 夕阳
+    pinyin: xī yáng
+  - chinese: 景色
+    pinyin: jǐng sè
+  - chinese: 。
+    pinyin: ''
+  english: When the sun sets, the western sky presents a beautiful sunset scenery.
+
+- segments:
+  - chinese: 记得
+    pinyin: jì de
+  - chinese: 向
+    pinyin: xiàng
+  - chinese: 西边
+    pinyin: xī biān
+  - chinese: 的
+    pinyin: de
+  - chinese: 花店
+    pinyin: huā diàn
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 在
+    pinyin: zài
+  - chinese: 那里
+    pinyin: nà li
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 到
+    pinyin: dào
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 的
+    pinyin: de
+  - chinese: 花
+    pinyin: huā
+  - chinese: 。
+    pinyin: ''
+  english: Remember to walk towards the flower shop on the west side; you can buy your favorite flowers there.
+
+- segments:
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 下边
+    pinyin: xià bian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 只
+    pinyin: zhǐ
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 。
+    pinyin: ''
+  english: There is a cat under the table.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 包
+    pinyin: bāo
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 椅子
+    pinyin: yǐ zi
+  - chinese: 下边
+    pinyin: xià bian
+  - chinese: 。
+    pinyin: ''
+  english: You can put your bag under the chair.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 栋
+    pinyin: dòng
+  - chinese: 楼
+    pinyin: lóu
+  - chinese: 的
+    pinyin: de
+  - chinese: 下边
+    pinyin: xià bian
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 层
+    pinyin: céng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 商场
+    pinyin: shāng chǎng
+  - chinese: 。
+    pinyin: ''
+  english: The lower floors of this building are a shopping mall.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 梯子
+    pinyin: tī zi
+  - chinese: 下边
+    pinyin: xià bian
+  - chinese: 修剪
+    pinyin: xiū jiǎn
+  - chinese: 草坪
+    pinyin: cǎo píng
+  - chinese: 。
+    pinyin: ''
+  english: He is trimming the lawn below the ladder.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 书
+    pinyin: shū
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 床
+    pinyin: chuáng
+  - chinese: 下边
+    pinyin: xià bian
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you put the book under the bed?
+
+- segments:
+  - chinese: 到
+    pinyin: dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 公交
+    pinyin: gōng jiāo
+  - chinese: 车站
+    pinyin: chē zhàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 下车
+    pinyin: xià chē
+  - chinese: 。
+    pinyin: ''
+  english: I'll get off at the bus stop.
+
+- segments:
+  - chinese: 火车
+    pinyin: huǒ chē
+  - chinese: 一
+    pinyin: yī
+  - chinese: 到
+    pinyin: dào
+  - chinese: 站
+    pinyin: zhàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 乘客
+    pinyin: chéng kè
+  - chinese: 们
+    pinyin: men
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 赶紧
+    pinyin: gǎn jǐn
+  - chinese: 下车
+    pinyin: xià chē
+  - chinese: 。
+    pinyin: ''
+  english: As soon as the train arrived at the station, the passengers hurriedly disembarked.
+
+- segments:
+  - chinese: 因为
+    pinyin: yīn wèi
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 没
+    pinyin: méi
+  - chinese: 能
+    pinyin: néng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 汽车
+    pinyin: qì chē
+  - chinese: 站
+    pinyin: zhàn
+  - chinese: 下车
+    pinyin: xià chē
+  - chinese: 。
+    pinyin: ''
+  english: Because of the rain, I couldn't get off at the bus station.
+
+- segments:
+  - chinese: 司机
+    pinyin: sī jī
+  - chinese: 宣布
+    pinyin: xuān bù
+  - chinese: 危险
+    pinyin: wēi xiǎn
+  - chinese: 过去
+    pinyin: guò qù
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 乘客
+    pinyin: chéng kè
+  - chinese: 们
+    pinyin: men
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 下车
+    pinyin: xià chē
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: The driver announced that the danger had passed, and passengers could disembark.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 妹妹
+    pinyin: mèi mei
+  - chinese: 是
+    pinyin: shì
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小学生
+    pinyin: xiǎo xué shēng
+  - chinese: 。
+    pinyin: ''
+  english: My younger sister is an elementary school student.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 二
+    pinyin: èr
+  - chinese: 百
+    pinyin: bǎi
+  - chinese: 名
+    pinyin: míng
+  - chinese: 小学生
+    pinyin: xiǎo xué shēng
+  - chinese: 。
+    pinyin: ''
+  english: This school has two hundred elementary school students.
+
+- segments:
+  - chinese: 小学生
+    pinyin: xiǎo xué shēng
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 早上
+    pinyin: zǎo shang
+  - chinese: 八
+    pinyin: bā
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 上课
+    pinyin: shàng kè
+  - chinese: 。
+    pinyin: ''
+  english: Elementary school students usually start classes at eight in the morning.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 教
+    pinyin: jiāo
+  - chinese: 小学生
+    pinyin: xiǎo xué shēng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 活力
+    pinyin: huó lì
+  - chinese: 。
+    pinyin: ''
+  english: I enjoy teaching elementary school students. They are very energetic.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 一块儿
+    pinyin: yī kuài r
+  - chinese: 去
+    pinyin: qù
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 。
+    pinyin: ''
+  english: Let's go to the park together.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 一块儿
+    pinyin: yī kuài r
+  - chinese: 长大
+    pinyin: zhǎng dà
+  - chinese: ，
+    pinyin: ''
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 像
+    pinyin: xiàng
+  - chinese: 兄弟
+    pinyin: xiōng dì
+  - chinese: 姐妹
+    pinyin: jiě mèi
+  - chinese: 一样
+    pinyin: yī yàng
+  - chinese: 。
+    pinyin: ''
+  english: They grew up together like brothers and sisters.
+
+- segments:
+  - chinese: 为了
+    pinyin: wèi le
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 完成
+    pinyin: wán chéng
+  - chinese: 得
+    pinyin: de
+  - chinese: 更
+    pinyin: gèng
+  - chinese: 快
+    pinyin: kuài
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 决定
+    pinyin: jué dìng
+  - chinese: 一块儿
+    pinyin: yī kuài r
+  - chinese: 努力
+    pinyin: nǔ lì
+  - chinese: 。
+    pinyin: ''
+  english: To finish the work faster, we decided to work together as a team.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 一块儿
+    pinyin: yī kuài r
+  - chinese: 唱歌
+    pinyin: chàng gē
+  - chinese: ，
+    pinyin: ''
+  - chinese: 声音
+    pinyin: shēng yīn
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 和谐
+    pinyin: hé xié
+  - chinese: 。
+    pinyin: ''
+  english: They sing together in harmony.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 出去
+    pinyin: chū qù
+  - chinese: 一下儿
+    pinyin: yī xià r
+  - chinese: ，
+    pinyin: ''
+  - chinese: 马上
+    pinyin: mǎ shàng
+  - chinese: 回来
+    pinyin: huí lai
+  - chinese: 。
+    pinyin: ''
+  english: I'll be right back; I'm just stepping out for a moment.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 等
+    pinyin: děng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一下儿
+    pinyin: yī xià r
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 快
+    pinyin: kuài
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: Wait for me just a moment; I'll be ready soon.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 打
+    pinyin: dǎ
+  - chinese: 电话
+    pinyin: diàn huà
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 晚
+    pinyin: wǎn
+  - chinese: 一点
+    pinyin: yī diǎn
+  - chinese: 会
+    pinyin: huì
+  - chinese: 到
+    pinyin: dào
+  - chinese: ，
+    pinyin: ''
+  - chinese: 要
+    pinyin: yào
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 等
+    pinyin: děng
+  - chinese: 他
+    pinyin: tā
+  - chinese: 一下儿
+    pinyin: yī xià r
+  - chinese: 。
+    pinyin: ''
+  english: He called to say he'd be a little late, and asked us to wait for him briefly.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 一下儿
+    pinyin: yī xià r
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 。
+    pinyin: ''
+  english: Let me take a quick look at how to cook this dish.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 孩子
+    pinyin: hái zi
+  - chinese: 一下儿
+    pinyin: yī xià r
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 洗手间
+    pinyin: xǐ shǒu jiān
+  - chinese: 。
+    pinyin: ''
+  english: Can you watch the kids for a moment while I go to the bathroom?
+
+- segments:
+  - chinese: 书架
+    pinyin: shū jià
+  - chinese: 在
+    pinyin: zài
+  - chinese: 一边
+    pinyin: yī biān
+  - chinese: ，
+    pinyin: ''
+  - chinese: 椅子
+    pinyin: yǐ zi
+  - chinese: 在
+    pinyin: zài
+  - chinese: 另
+    pinyin: lìng
+  - chinese: 一边
+    pinyin: yī biān
+  - chinese: 。
+    pinyin: ''
+  english: The bookshelf is on one side, and the chair is on the other.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 栋
+    pinyin: dòng
+  - chinese: 楼
+    pinyin: lóu
+  - chinese: 的
+    pinyin: de
+  - chinese: 一边
+    pinyin: yī biān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: ，
+    pinyin: ''
+  - chinese: 另
+    pinyin: lìng
+  - chinese: 一边
+    pinyin: yī biān
+  - chinese: 是
+    pinyin: shì
+  - chinese: 商场
+    pinyin: shāng chǎng
+  - chinese: 。
+    pinyin: ''
+  english: One side of this building faces the park, and the other side faces the mall.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一边
+    pinyin: yī biān
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 音乐
+    pinyin: yīn yuè
+  - chinese: 一边
+    pinyin: yī biān
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 。
+    pinyin: ''
+  english: I work while listening to music.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 一边
+    pinyin: yī biān
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 早饭
+    pinyin: zǎo fàn
+  - chinese: 一边
+    pinyin: yī biān
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 新闻
+    pinyin: xīn wén
+  - chinese: 。
+    pinyin: ''
+  english: She reads the news while eating breakfast.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 一边
+    pinyin: yī biān
+  - chinese: 散步
+    pinyin: sàn bù
+  - chinese: 一边
+    pinyin: yī biān
+  - chinese: 欣赏
+    pinyin: xīn shǎng
+  - chinese: 美景
+    pinyin: měi jǐng
+  - chinese: 。
+    pinyin: ''
+  english: You can enjoy the beautiful scenery while taking a walk.
+
+- segments:
+  - chinese: 有的
+    pinyin: yǒu de
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 数学
+    pinyin: shù xué
+  - chinese: ，
+    pinyin: ''
+  - chinese: 有的
+    pinyin: yǒu de
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 语文
+    pinyin: yǔ wén
+  - chinese: 。
+    pinyin: ''
+  english: Some students like math, some like language arts.
+
+- segments:
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 有的
+    pinyin: yǒu de
+  - chinese: 又
+    pinyin: yòu
+  - chinese: 大
+    pinyin: dà
+  - chinese: 又
+    pinyin: yòu
+  - chinese: 红
+    pinyin: hóng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 有的
+    pinyin: yǒu de
+  - chinese: 又
+    pinyin: yòu
+  - chinese: 小
+    pinyin: xiǎo
+  - chinese: 又
+    pinyin: yòu
+  - chinese: 青
+    pinyin: qīng
+  - chinese: 。
+    pinyin: ''
+  english: Some apples are big and red, some are small and green.
+
+- segments:
+  - chinese: 班上
+    pinyin: bān shàng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 有的
+    pinyin: yǒu de
+  - chinese: 在
+    pinyin: zài
+  - chinese: 读书
+    pinyin: dú shū
+  - chinese: ，
+    pinyin: ''
+  - chinese: 有的
+    pinyin: yǒu de
+  - chinese: 在
+    pinyin: zài
+  - chinese: 写字
+    pinyin: xiě zì
+  - chinese: 。
+    pinyin: ''
+  english: In the classroom, some students are reading, and some are writing.
+
+- segments:
+  - chinese: 有的
+    pinyin: yǒu de
+  - chinese: 花
+    pinyin: huā
+  - chinese: 香
+    pinyin: xiāng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 有的
+    pinyin: yǒu de
+  - chinese: 好看
+    pinyin: hǎo kàn
+  - chinese: 。
+    pinyin: ''
+  english: Some flowers are fragrant, and some are beautiful.
+
+- segments:
+  - chinese: 有的
+    pinyin: yǒu de
+  - chinese: 同学
+    pinyin: tóng xué
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 打
+    pinyin: dǎ
+  - chinese: 篮球
+    pinyin: lán qiú
+  - chinese: ，
+    pinyin: ''
+  - chinese: 有的
+    pinyin: yǒu de
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 踢
+    pinyin: tī
+  - chinese: 足球
+    pinyin: zú qiú
+  - chinese: 。
+    pinyin: ''
+  english: Some classmates like playing basketball, and some like playing soccer.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 书
+    pinyin: shū
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 的
+    pinyin: de
+  - chinese: 右边
+    pinyin: yòu bian
+  - chinese: 。
+    pinyin: ''
+  english: My book is on the right side of the table.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 看到
+    pinyin: kàn dào
+  - chinese: 路牌
+    pinyin: lù pái
+  - chinese: 了
+    pinyin: le
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  - chinese: 加油站
+    pinyin: jiā yóu zhàn
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 在
+    pinyin: zài
+  - chinese: 右边
+    pinyin: yòu bian
+  - chinese: 。
+    pinyin: ''
+  english: Do you see the road sign? The gas station is right there on the right.
+
+- segments:
+  - chinese: 右边
+    pinyin: yòu bian
+  - chinese: 那
+    pinyin: nà
+  - chinese: 栋
+    pinyin: dòng
+  - chinese: 黄色
+    pinyin: huáng sè
+  - chinese: 大楼
+    pinyin: dà lóu
+  - chinese: 是
+    pinyin: shì
+  - chinese: 市政厅
+    pinyin: shì zhèng tīng
+  - chinese: 。
+    pinyin: ''
+  english: The tall yellow building on the right is the city hall.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 朝
+    pinyin: cháo
+  - chinese: 右边
+    pinyin: yòu bian
+  - chinese: 转
+    pinyin: zhuǎn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不要
+    pinyin: bù yào
+  - chinese: 往
+    pinyin: wǎng
+  - chinese: 左边
+    pinyin: zuǒ bian
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 。
+    pinyin: ''
+  english: You should turn right, not left.
+
+- segments:
+  - chinese: 右边
+    pinyin: yòu bian
+  - chinese: 那
+    pinyin: nà
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 餐厅
+    pinyin: cān tīng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 好吃
+    pinyin: hǎo chī
+  - chinese: 的
+    pinyin: de
+  - chinese: 比萨
+    pinyin: bǐ sà
+  - chinese: 。
+    pinyin: ''
+  english: The restaurant on the right serves delicious pizza.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 晚饭
+    pinyin: wǎn fàn
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 请客
+    pinyin: qǐng kè
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不客气
+    pinyin: bù kè qi
+  - chinese: ！
+    pinyin: ''
+  english: Dinner is on me tonight. Don't worry about it!
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 随便
+    pinyin: suí biàn
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不客气
+    pinyin: bù kè qi
+  - chinese: 。
+    pinyin: ''
+  english: Please sit anywhere, don't be formal.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 加
+    pinyin: jiā
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 奶
+    pinyin: nǎi
+  - chinese: ？
+    pinyin: ''
+  english: What kind of milk do you want in your coffee?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 女儿
+    pinyin: nǚ ér
+  - chinese: 在
+    pinyin: zài
+  - chinese: 附近
+    pinyin: fù jìn
+  - chinese: 的
+    pinyin: de
+  - chinese: 小学
+    pinyin: xiǎo xué
+  - chinese: 上学
+    pinyin: shàng xué
+  - chinese: 。
+    pinyin: ''
+  english: My daughter attends the elementary school nearby.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 小学
+    pinyin: xiǎo xué
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 数学
+    pinyin: shù xué
+  - chinese: 课
+    pinyin: kè
+  - chinese: 。
+    pinyin: ''
+  english: He liked math class the most when he was in elementary school.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 小学
+    pinyin: xiǎo xué
+  - chinese: 毕业
+    pinyin: bì yè
+  - chinese: 前
+    pinyin: qián
+  - chinese: 要
+    pinyin: yào
+  - chinese: 参加
+    pinyin: cān jiā
+  - chinese: 一
+    pinyin: yī
+  - chinese: 场
+    pinyin: chǎng
+  - chinese: 考试
+    pinyin: kǎo shì
+  - chinese: 。
+    pinyin: ''
+  english: We need to take an exam before graduating from elementary school.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 小学
+    pinyin: xiǎo xué
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 的
+    pinyin: de
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 是
+    pinyin: shì
+  - chinese: 谁
+    pinyin: shéi
+  - chinese: ？
+    pinyin: ''
+  english: Who was your favorite teacher when you were in elementary school?
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 小学
+    pinyin: xiǎo xué
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 学
+    pinyin: xué
+  - chinese: 到
+    pinyin: dào
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 基础
+    pinyin: jī chǔ
+  - chinese: 知识
+    pinyin: zhī shi
+  - chinese: 。
+    pinyin: ''
+  english: We learned a lot of basic knowledge in elementary school.
+
+- segments:
+  - chinese: 这里
+    pinyin: zhè lǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 女
+    pinyin: nǚ
+  - chinese: 厕所
+    pinyin: cè suǒ
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Is there a women's restroom here?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 女
+    pinyin: nǚ
+  - chinese: 厕所
+    pinyin: cè suǒ
+  - chinese: 。
+    pinyin: ''
+  english: This is the women's bathroom.
+
+- segments:
+  - chinese: 往
+    pinyin: wǎng
+  - chinese: 右
+    pinyin: yòu
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 街区
+    pinyin: jiē qū
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 到
+    pinyin: dào
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: Go right for two blocks and you'll arrive at my house.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 右
+    pinyin: yòu
+  - chinese: 眼
+    pinyin: yǎn
+  - chinese: 比
+    pinyin: bǐ
+  - chinese: 左
+    pinyin: zuǒ
+  - chinese: 眼
+    pinyin: yǎn
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 得
+    pinyin: de
+  - chinese: 清楚
+    pinyin: qīng chu
+  - chinese: 。
+    pinyin: ''
+  english: My right eye has better vision than my left one.
+
+- segments:
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 的
+    pinyin: de
+  - chinese: 教学楼
+    pinyin: jiào xué lóu
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 三
+    pinyin: sān
+  - chinese: 层
+    pinyin: céng
+  - chinese: 。
+    pinyin: ''
+  english: The new academic building has three floors.
+
+- segments:
+  - chinese: 历史
+    pinyin: lì shǐ
+  - chinese: 课
+    pinyin: kè
+  - chinese: 在
+    pinyin: zài
+  - chinese: 教学楼
+    pinyin: jiào xué lóu
+  - chinese: 的
+    pinyin: de
+  - chinese: 顶层
+    pinyin: dǐng céng
+  - chinese: 举行
+    pinyin: jǔ xíng
+  - chinese: 。
+    pinyin: ''
+  english: The history class is held on the top floor of the classroom building.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 教学楼
+    pinyin: jiào xué lóu
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 找到
+    pinyin: zhǎo dào
+  - chinese: 校长
+    pinyin: xiào zhǎng
+  - chinese: 办公室
+    pinyin: bàn gōng shì
+  - chinese: 。
+    pinyin: ''
+  english: You can find the principal's office inside the academic building.
+
+- segments:
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 教学楼
+    pinyin: jiào xué lóu
+  - chinese: 的
+    pinyin: de
+  - chinese: 前面
+    pinyin: qián miàn
+  - chinese: 玩耍
+    pinyin: wán shuǎ
+  - chinese: 。
+    pinyin: ''
+  english: The students are playing in front of the classroom building.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 数学
+    pinyin: shù xué
+  - chinese: 课
+    pinyin: kè
+  - chinese: 在
+    pinyin: zài
+  - chinese: 主
+    pinyin: zhǔ
+  - chinese: 教学楼
+    pinyin: jiào xué lóu
+  - chinese: 。
+    pinyin: ''
+  english: My math class is in the main academic building.
+
+- segments:
+  - chinese: 别人
+    pinyin: bié ren
+  - chinese: 的
+    pinyin: de
+  - chinese: 意见
+    pinyin: yì jiàn
+  - chinese: 不
+    pinyin: bù
+  - chinese: 重要
+    pinyin: zhòng yào
+  - chinese: 。
+    pinyin: ''
+  english: Others' opinions don't matter.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不能
+    pinyin: bù néng
+  - chinese: 总
+    pinyin: zǒng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 依靠
+    pinyin: yī kào
+  - chinese: 别人
+    pinyin: bié ren
+  - chinese: 。
+    pinyin: ''
+  english: You can't always rely on others.
+
+- segments:
+  - chinese: 别人
+    pinyin: bié ren
+  - chinese: 的
+    pinyin: de
+  - chinese: 生活
+    pinyin: shēng huó
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 似
+    pinyin: sì
+  - chinese: 更
+    pinyin: gèng
+  - chinese: 美好
+    pinyin: měi hǎo
+  - chinese: 。
+    pinyin: ''
+  english: Others' lives seem more pleasant.
+
+- segments:
+  - chinese: 不
+    pinyin: bù
+  - chinese: 要
+    pinyin: yào
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 别人
+    pinyin: bié ren
+  - chinese: 比较
+    pinyin: bǐ jiào
+  - chinese: ，
+    pinyin: ''
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 最好
+    pinyin: zuì hǎo
+  - chinese: 的
+    pinyin: de
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 。
+    pinyin: ''
+  english: Don't compare yourself to others; be the best version of yourself.
+
+- segments:
+  - chinese: 尊重
+    pinyin: zūn zhòng
+  - chinese: 别人
+    pinyin: bié ren
+  - chinese: 也
+    pinyin: yě
+  - chinese: 尊重
+    pinyin: zūn zhòng
+  - chinese: 自己
+    pinyin: zì jǐ
+  - chinese: 。
+    pinyin: ''
+  english: Respect others and respect yourself.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 没
+    pinyin: méi
+  - chinese: 穿
+    pinyin: chuān
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 。
+    pinyin: ''
+  english: I am not wearing any clothes.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 从
+    pinyin: cóng
+  - chinese: 北京
+    pinyin: Běi jīng
+  - chinese: 来
+    pinyin: lái
+  - chinese: 。
+    pinyin: ''
+  english: I am from Beijing.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 从
+    pinyin: cóng
+  - chinese: 那
+    pinyin: nà
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 学到
+    pinyin: xué dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What have you learned from that book?
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 承认
+    pinyin: chéng rèn
+  - chinese: 自己
+    pinyin: zì jǐ
+  - chinese: 错
+    pinyin: cuò
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: She admitted that she was wrong.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 错
+    pinyin: cuò
+  - chinese: 。
+    pinyin: ''
+  english: You are not wrong.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 床
+    pinyin: chuáng
+  - chinese: 。
+    pinyin: ''
+  english: I need a new bed.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 床
+    pinyin: chuáng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 舒服
+    pinyin: shū fu
+  - chinese: 。
+    pinyin: ''
+  english: My bed is very comfortable.
+
+- segments:
+  - chinese: 孩子们
+    pinyin: hái zi men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 床
+    pinyin: chuáng
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 跳
+    pinyin: tiào
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 跳
+    pinyin: tiào
+  - chinese: 下
+    pinyin: xià
+  - chinese: 。
+    pinyin: ''
+  english: The children are jumping on the bed.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 书
+    pinyin: shū
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 床
+    pinyin: chuáng
+  - chinese: 边
+    pinyin: biān
+  - chinese: 。
+    pinyin: ''
+  english: You put the book by the bed.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 床
+    pinyin: chuáng
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 躺
+    pinyin: tǎng
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: 。
+    pinyin: ''
+  english: I lay on the bed for an hour.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 床
+    pinyin: chuáng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 大
+    pinyin: dà
+  - chinese: 。
+    pinyin: ''
+  english: My bed is very big.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 哥哥
+    pinyin: gē ge
+  - chinese: 在
+    pinyin: zài
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 床
+    pinyin: chuáng
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 睡觉
+    pinyin: shuì jiào
+  - chinese: 。
+    pinyin: ''
+  english: My brother sleeps in my bed.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 班
+    pinyin: bān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 二十
+    pinyin: èr shí
+  - chinese: 个
+    pinyin: gè
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 。
+    pinyin: ''
+  english: This class has twenty students.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 班
+    pinyin: bān
+  - chinese: 赢
+    pinyin: yíng
+  - chinese: 了
+    pinyin: le
+  - chinese: 足球
+    pinyin: zú qiú
+  - chinese: 比赛
+    pinyin: bǐ sài
+  - chinese: 。
+    pinyin: ''
+  english: Our class won the soccer match.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 班
+    pinyin: bān
+  - chinese: 的
+    pinyin: de
+  - chinese: 同学
+    pinyin: tóng xué
+  - chinese: 。
+    pinyin: ''
+  english: I like the classmates in this class.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪
+    pinyin: nǎ
+  - chinese: 个
+    pinyin: gè
+  - chinese: 班
+    pinyin: bān
+  - chinese: ？
+    pinyin: ''
+  english: Which class are you in?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 花
+    pinyin: huā
+  - chinese: 了
+    pinyin: le
+  - chinese: 半天
+    pinyin: bàn tiān
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 整理
+    pinyin: zhěng lǐ
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 。
+    pinyin: ''
+  english: I spent half a day cleaning my room.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 讨论
+    pinyin: tǎo lùn
+  - chinese: 了
+    pinyin: le
+  - chinese: 半天
+    pinyin: bàn tiān
+  - chinese: 还是
+    pinyin: hái shi
+  - chinese: 没
+    pinyin: méi
+  - chinese: 决定
+    pinyin: jué dìng
+  - chinese: 。
+    pinyin: ''
+  english: They discussed for half a day but still couldn't decide.
+
+- segments:
+  - chinese: 半天
+    pinyin: bàn tiān
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 过去
+    pinyin: guò qù
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: Half a day has already passed.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 半天
+    pinyin: bàn tiān
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: ，
+    pinyin: ''
+  - chinese: 半天
+    pinyin: bàn tiān
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 。
+    pinyin: ''
+  english: We can work for half a day and study for the other half.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 半天
+    pinyin: bàn tiān
+  - chinese: 没
+    pinyin: méi
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I haven't eaten for half a day.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 半天
+    pinyin: bàn tiān
+  - chinese: 后
+    pinyin: hòu
+  - chinese: 才
+    pinyin: cái
+  - chinese: 到达
+    pinyin: dào dá
+  - chinese: 。
+    pinyin: ''
+  english: They will arrive half a day later.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 份
+    pinyin: fèn
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 只
+    pinyin: zhǐ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 半天
+    pinyin: bàn tiān
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 。
+    pinyin: ''
+  english: This job only takes half a day.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 半天
+    pinyin: bàn tiān
+  - chinese: 没
+    pinyin: méi
+  - chinese: 见到
+    pinyin: jiàn dào
+  - chinese: 他
+    pinyin: tā
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: We haven't seen him for half a day.
+
+- segments:
+  - chinese: 半天
+    pinyin: bàn tiān
+  - chinese: 后
+    pinyin: hòu
+  - chinese: 再
+    pinyin: zài
+  - chinese: 试试看
+    pinyin: shì shì kàn
+  - chinese: 。
+    pinyin: ''
+  english: Let's try again after half a day.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 包
+    pinyin: bāo
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 大
+    pinyin: dà
+  - chinese: 。
+    pinyin: ''
+  english: This bag is very big.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 包包
+    pinyin: bāo bāo
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 重
+    pinyin: zhòng
+  - chinese: 。
+    pinyin: ''
+  english: My bag is very heavy.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 和
+    pinyin: hé
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 差
+    pinyin: chà
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 。
+    pinyin: ''
+  english: Your clothes are quite different from mine.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 首
+    pinyin: shǒu
+  - chinese: 歌
+    pinyin: gē
+  - chinese: 叫
+    pinyin: jiào
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 名字
+    pinyin: míng zi
+  - chinese: ？
+    pinyin: ''
+  english: What's the name of this song?
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 唱
+    pinyin: chàng
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 首
+    pinyin: shǒu
+  - chinese: 歌
+    pinyin: gē
+  - chinese: 。
+    pinyin: ''
+  english: She sang a song.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 车票
+    pinyin: chē piào
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you have a ticket?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 车票
+    pinyin: chē piào
+  - chinese: 。
+    pinyin: ''
+  english: I need to buy two tickets.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 车票
+    pinyin: chē piào
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪
+    pinyin: nǎ
+  - chinese: 了
+    pinyin: le
+  - chinese: ？
+    pinyin: ''
+  english: Where did you put the tickets?
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 巴士
+    pinyin: bā shì
+  - chinese: 车票
+    pinyin: chē piào
+  - chinese: 。
+    pinyin: ''
+  english: We're going to buy bus tickets.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 打开
+    pinyin: dǎ kāi
+  - chinese: 门
+    pinyin: mén
+  - chinese: 。
+    pinyin: ''
+  english: Please open the door.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 打开
+    pinyin: dǎ kāi
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 盒子
+    pinyin: hé zi
+  - chinese: ？
+    pinyin: ''
+  english: How do I open this box?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 打开
+    pinyin: dǎ kāi
+  - chinese: 书
+    pinyin: shū
+  - chinese: ，
+    pinyin: ''
+  - chinese: 然后
+    pinyin: rán hòu
+  - chinese: 开始
+    pinyin: kāi shǐ
+  - chinese: 读
+    pinyin: dú
+  - chinese: 。
+    pinyin: ''
+  english: You open the book and then start reading.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 打开
+    pinyin: dǎ kāi
+  - chinese: 窗户
+    pinyin: chuāng hu
+  - chinese: 通通
+    pinyin: tōng tōng
+  - chinese: 风
+    pinyin: fēng
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you open the window for ventilation?
+
+- segments:
+  - chinese: 不
+    pinyin: bù
+  - chinese: 要
+    pinyin: yào
+  - chinese: 打开
+    pinyin: dǎ kāi
+  - chinese: 冰箱
+    pinyin: bīng xiāng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 里面
+    pinyin: lǐ miàn
+  - chinese: 没
+    pinyin: méi
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: Don't open the refrigerator, there's no food inside.
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 晚上
+    pinyin: wǎn shang
+  - chinese: 下
+    pinyin: xià
+  - chinese: 了
+    pinyin: le
+  - chinese: 点儿
+    pinyin: diǎn r
+  - chinese: 小雨
+    pinyin: xiǎo yǔ
+  - chinese: 。
+    pinyin: ''
+  english: There was a light drizzle last night.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 会
+    pinyin: huì
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Will it rain today?
+
+- segments:
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 晚上
+    pinyin: wǎn shang
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 雨
+    pinyin: yǔ
+  - chinese: 。
+    pinyin: ''
+  english: There was rain last night.
+
+- segments:
+  - chinese: 下
+    pinyin: xià
+  - chinese: 大雨
+    pinyin: dà yǔ
+  - chinese: 时
+    pinyin: shí
+  - chinese: ，
+    pinyin: ''
+  - chinese: 记得
+    pinyin: jì de
+  - chinese: 带
+    pinyin: dài
+  - chinese: 雨伞
+    pinyin: yǔ sǎn
+  - chinese: 。
+    pinyin: ''
+  english: Remember to bring an umbrella when it rains heavily.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: 的
+    pinyin: de
+  - chinese: 声音
+    pinyin: shēng yīn
+  - chinese: 。
+    pinyin: ''
+  english: I enjoy listening to the sound of rain.
+
+- segments:
+  - chinese: 因为
+    pinyin: yīn wèi
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 取消
+    pinyin: qǔ xiāo
+  - chinese: 了
+    pinyin: le
+  - chinese: 野餐
+    pinyin: yě cān
+  - chinese: 计划
+    pinyin: jì huà
+  - chinese: 。
+    pinyin: ''
+  english: We canceled the picnic plans because of the rain.
+
+- segments:
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 请问
+    pinyin: qǐng wèn
+  - chinese: 厕所
+    pinyin: cè suǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: ？
+    pinyin: ''
+  english: Sir, where is the restroom?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 位
+    pinyin: wèi
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 。
+    pinyin: ''
+  english: This gentleman is my friend.
+
+- segments:
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 您
+    pinyin: nín
+  - chinese: 想要
+    pinyin: xiǎng yào
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 饮料
+    pinyin: yǐn liào
+  - chinese: ？
+    pinyin: ''
+  english: Sir, what beverage would you like?
+
+- segments:
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 您
+    pinyin: nín
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 票
+    pinyin: piào
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Sir, do you have a ticket?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 星期天
+    pinyin: Xīng qī tiān
+  - chinese: ，
+    pinyin: ''
+  - chinese: 因为
+    pinyin: yīn wèi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 用
+    pinyin: yòng
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 。
+    pinyin: ''
+  english: I like Sundays because I don't have to work.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 星期天
+    pinyin: Xīng qī tiān
+  - chinese: 去
+    pinyin: qù
+  - chinese: 动物园
+    pinyin: dòng wù yuán
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Let's go to the zoo on Sunday.
+
+- segments:
+  - chinese: 星期天
+    pinyin: Xīng qī tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 睡
+    pinyin: shuì
+  - chinese: 到
+    pinyin: dào
+  - chinese: 中午
+    pinyin: zhōng wǔ
+  - chinese: 。
+    pinyin: ''
+  english: I usually sleep until noon on Sundays.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 星期天
+    pinyin: Xīng qī tiān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 计划
+    pinyin: jì huà
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you have any plans for Sunday?
+
+- segments:
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 在
+    pinyin: zài
+  - chinese: 星期天
+    pinyin: Xīng qī tiān
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 关门
+    pinyin: guān mén
+  - chinese: 。
+    pinyin: ''
+  english: Shops are usually closed on Sundays.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 星期天
+    pinyin: Xīng qī tiān
+  - chinese: 去
+    pinyin: qù
+  - chinese: 电影院
+    pinyin: diàn yǐng yuàn
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Let's go to the cinema on Sunday.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 瓶
+    pinyin: píng
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 元
+    pinyin: yuán
+  - chinese: 。
+    pinyin: ''
+  english: This bottle of water costs two yuan.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 只有
+    pinyin: zhǐ yǒu
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 元
+    pinyin: yuán
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不够
+    pinyin: bù gòu
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I only have five yuan, not enough to buy a book.
+
+- segments:
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 一
+    pinyin: yī
+  - chinese: 元
+    pinyin: yuán
+  - chinese: 钱
+    pinyin: qián
+  - chinese: 。
+    pinyin: ''
+  english: An apple costs one yuan.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 换
+    pinyin: huàn
+  - chinese: 五十
+    pinyin: wǔ shí
+  - chinese: 元
+    pinyin: yuán
+  - chinese: 的
+    pinyin: de
+  - chinese: 零钱
+    pinyin: líng qián
+  - chinese: 。
+    pinyin: ''
+  english: I want to exchange fifty yuan for smaller denominations.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 便宜
+    pinyin: pián yi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 只
+    pinyin: zhǐ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 十
+    pinyin: shí
+  - chinese: 元
+    pinyin: yuán
+  - chinese: 。
+    pinyin: ''
+  english: This piece of clothing is very cheap, only ten yuan.
+
+- segments:
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 票
+    pinyin: piào
+  - chinese: 是
+    pinyin: shì
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 元
+    pinyin: yuán
+  - chinese: 。
+    pinyin: ''
+  english: One cinema ticket is five yuan.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 是
+    pinyin: shì
+  - chinese: 二十
+    pinyin: èr shí
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 元
+    pinyin: yuán
+  - chinese: 。
+    pinyin: ''
+  english: This piece of clothing is twenty-five yuan.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 是
+    pinyin: shì
+  - chinese: 十
+    pinyin: shí
+  - chinese: 元
+    pinyin: yuán
+  - chinese: 。
+    pinyin: ''
+  english: This piece of clothing is ten yuan.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 书
+    pinyin: shū
+  - chinese: 旁边
+    pinyin: páng biān
+  - chinese: 找到
+    pinyin: zhǎo dào
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 元
+    pinyin: yuán
+  - chinese: 。
+    pinyin: ''
+  english: I found five yuan next to my book.
+
+- segments:
+  - chinese: 最好
+    pinyin: zuì hǎo
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 不
+    pinyin: bù
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 海滩
+    pinyin: hǎi tān
+  - chinese: ，
+    pinyin: ''
+  - chinese: 因为
+    pinyin: yīn wèi
+  - chinese: 会
+    pinyin: huì
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: 。
+    pinyin: ''
+  english: It's best not to go to the beach today because it will rain.
+
+- segments:
+  - chinese: 最好
+    pinyin: zuì hǎo
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 早点
+    pinyin: zǎo diǎn
+  - chinese: 儿
+    pinyin: r
+  - chinese: 来
+    pinyin: lái
+  - chinese: 。
+    pinyin: ''
+  english: It's best if you can come earlier.
+
+- segments:
+  - chinese: 学
+    pinyin: xué
+  - chinese: 一
+    pinyin: yī
+  - chinese: 门
+    pinyin: mén
+  - chinese: 外语
+    pinyin: wài yǔ
+  - chinese: 时
+    pinyin: shí
+  - chinese: ，
+    pinyin: ''
+  - chinese: 最好
+    pinyin: zuì hǎo
+  - chinese: 去
+    pinyin: qù
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 国家
+    pinyin: guó jiā
+  - chinese: 。
+    pinyin: ''
+  english: When learning a foreign language, it's best to go to that country.
+
+- segments:
+  - chinese: 爬山
+    pinyin: pá shān
+  - chinese: 最好
+    pinyin: zuì hǎo
+  - chinese: 穿
+    pinyin: chuān
+  - chinese: 运动鞋
+    pinyin: yùn dòng xié
+  - chinese: 。
+    pinyin: ''
+  english: It's best to wear sports shoes for hiking.
+
+- segments:
+  - chinese: 最好
+    pinyin: zuì hǎo
+  - chinese: 现在
+    pinyin: xiàn zài
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 吃药
+    pinyin: chī yào
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不
+    pinyin: bù
+  - chinese: 要
+    pinyin: yào
+  - chinese: 等
+    pinyin: děng
+  - chinese: 太
+    pinyin: tài
+  - chinese: 久
+    pinyin: jiǔ
+  - chinese: 。
+    pinyin: ''
+  english: It's best to take the medicine now and not wait too long.
+
+- segments:
+  - chinese: 最后
+    pinyin: zuì hòu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 赢
+    pinyin: yíng
+  - chinese: 了
+    pinyin: le
+  - chinese: 比赛
+    pinyin: bǐ sài
+  - chinese: 。
+    pinyin: ''
+  english: Finally, they won the game.
+
+- segments:
+  - chinese: 经过
+    pinyin: jīng guò
+  - chinese: 多年
+    pinyin: duō nián
+  - chinese: 的
+    pinyin: de
+  - chinese: 努力
+    pinyin: nǔ lì
+  - chinese: ，
+    pinyin: ''
+  - chinese: 他
+    pinyin: tā
+  - chinese: 最后
+    pinyin: zuì hòu
+  - chinese: 成功
+    pinyin: chéng gōng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: After years of hard work, he finally succeeded.
+
+- segments:
+  - chinese: 最后
+    pinyin: zuì hòu
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 分钟
+    pinyin: fēn zhōng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 她
+    pinyin: tā
+  - chinese: 赶
+    pinyin: gǎn
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 了
+    pinyin: le
+  - chinese: 火车
+    pinyin: huǒ chē
+  - chinese: 。
+    pinyin: ''
+  english: In the last two minutes, she caught the train.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 的
+    pinyin: de
+  - chinese: 最后
+    pinyin: zuì hòu
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 章
+    pinyin: zhāng
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 精彩
+    pinyin: jīng cǎi
+  - chinese: 。
+    pinyin: ''
+  english: The last few chapters of this book are the most exciting.
+
+- segments:
+  - chinese: 最后
+    pinyin: zuì hòu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 感谢
+    pinyin: gǎn xiè
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 家人
+    pinyin: jiā rén
+  - chinese: 。
+    pinyin: ''
+  english: Finally, I want to thank my family.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 得到
+    pinyin: dé dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 奖学金
+    pinyin: jiǎng xué jīn
+  - chinese: 。
+    pinyin: ''
+  english: I got a scholarship.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 得到
+    pinyin: dé dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 回复
+    pinyin: huí fù
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Did you get a reply from him?
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 得到
+    pinyin: dé dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 生日
+    pinyin: shēng rì
+  - chinese: 礼物
+    pinyin: lǐ wù
+  - chinese: 。
+    pinyin: ''
+  english: She received a lot of birthday gifts.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 终于
+    pinyin: zhōng yú
+  - chinese: 得到
+    pinyin: dé dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 消息
+    pinyin: xiāo xi
+  - chinese: 。
+    pinyin: ''
+  english: We finally received good news.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 努力
+    pinyin: nǔ lì
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: ，
+    pinyin: ''
+  - chinese: 得到
+    pinyin: dé dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 上司
+    pinyin: shàng si
+  - chinese: 的
+    pinyin: de
+  - chinese: 赞赏
+    pinyin: zàn shǎng
+  - chinese: 。
+    pinyin: ''
+  english: He worked hard and gained appreciation from his boss.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 第
+    pinyin: dì
+  - chinese: 三
+    pinyin: sān
+  - chinese: 个
+    pinyin: gè
+  - chinese: 选项
+    pinyin: xuǎn xiàng
+  - chinese: 。
+    pinyin: ''
+  english: This is the third option.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 住
+    pinyin: zhù
+  - chinese: 在
+    pinyin: zài
+  - chinese: 街道
+    pinyin: jiē dào
+  - chinese: 的
+    pinyin: de
+  - chinese: 第
+    pinyin: dì
+  - chinese: 十二
+    pinyin: shí èr
+  - chinese: 号
+    pinyin: hào
+  - chinese: 房子
+    pinyin: fáng zi
+  - chinese: 。
+    pinyin: ''
+  english: We live in the 12th house on the street.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 生日
+    pinyin: shēng rì
+  - chinese: 是
+    pinyin: shì
+  - chinese: 五月
+    pinyin: Wǔ yuè
+  - chinese: 三
+    pinyin: sān
+  - chinese: 日
+    pinyin: rì
+  - chinese: 。
+    pinyin: ''
+  english: My birthday is the 3rd day of May.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 的
+    pinyin: de
+  - chinese: 第
+    pinyin: dì
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 章
+    pinyin: zhāng
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 难
+    pinyin: nán
+  - chinese: 懂
+    pinyin: dǒng
+  - chinese: 。
+    pinyin: ''
+  english: The 5th chapter of this book is the most difficult to understand.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 班
+    pinyin: bān
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 的
+    pinyin: de
+  - chinese: 第
+    pinyin: dì
+  - chinese: 二
+    pinyin: èr
+  - chinese: 名
+    pinyin: míng
+  - chinese: 。
+    pinyin: ''
+  english: He is the second-ranked student in the class.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 手机
+    pinyin: shǒu jī
+  - chinese: 没
+    pinyin: méi
+  - chinese: 电
+    pinyin: diàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: My phone ran out of battery.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 电视机
+    pinyin: diàn shì jī
+  - chinese: 。
+    pinyin: ''
+  english: I do not have a TV set in my room.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 地上
+    pinyin: dì shang
+  - chinese: ？
+    pinyin: ''
+  english: Why are you sitting on the ground?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 妹妹
+    pinyin: mèi mei
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 地上
+    pinyin: dì shang
+  - chinese: 。
+    pinyin: ''
+  english: My little sister is sitting on the ground.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 饿
+    pinyin: è
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I'm hungry.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 看起来
+    pinyin: kàn qǐ lai
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 饿
+    pinyin: è
+  - chinese: 。
+    pinyin: ''
+  english: You look hungry.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 太
+    pinyin: tài
+  - chinese: 饿
+    pinyin: è
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 行
+    pinyin: xíng
+  - chinese: 。
+    pinyin: ''
+  english: I'm so hungry, anything to eat is fine.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 先
+    pinyin: xiān
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 早饭
+    pinyin: zǎo fàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 否则
+    pinyin: fǒu zé
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 饿
+    pinyin: è
+  - chinese: 。
+    pinyin: ''
+  english: You should eat breakfast first, otherwise, you'll get hungry.
+
+- segments:
+  - chinese: 孩子们
+    pinyin: hái zi men
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 整
+    pinyin: zhěng
+  - chinese: 天
+    pinyin: tiān
+  - chinese: ，
+    pinyin: ''
+  - chinese: 现在
+    pinyin: xiàn zài
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 饿
+    pinyin: è
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: The children played all day and are now all hungry.
+
+- segments:
+  - chinese: 放学
+    pinyin: fàng xué
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 回家
+    pinyin: huí jiā
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: School is over, I'm going home.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 放学
+    pinyin: fàng xué
+  - chinese: 后
+    pinyin: hòu
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What do you usually do after school?
+
+- segments:
+  - chinese: 放学
+    pinyin: fàng xué
+  - chinese: 后
+    pinyin: hòu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 钢琴
+    pinyin: gāng qín
+  - chinese: 课
+    pinyin: kè
+  - chinese: 。
+    pinyin: ''
+  english: After school, I go to piano lessons.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 放学
+    pinyin: fàng xué
+  - chinese: 后
+    pinyin: hòu
+  - chinese: 接
+    pinyin: jiē
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you pick me up after school?
+
+- segments:
+  - chinese: 放学
+    pinyin: fàng xué
+  - chinese: 高峰期
+    pinyin: gāo fēng qī
+  - chinese: ，
+    pinyin: ''
+  - chinese: 交通
+    pinyin: jiāo tōng
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 拥挤
+    pinyin: yōng jǐ
+  - chinese: 。
+    pinyin: ''
+  english: During the after-school rush, traffic is usually congested.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 放假
+    pinyin: fàng jià
+  - chinese: 。
+    pinyin: ''
+  english: We will have a day off tomorrow.
+
+- segments:
+  - chinese: 因为
+    pinyin: yīn wèi
+  - chinese: 下雪
+    pinyin: xià xuě
+  - chinese: ，
+    pinyin: ''
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 放假
+    pinyin: fàng jià
+  - chinese: 一
+    pinyin: yī
+  - chinese: 天
+    pinyin: tiān
+  - chinese: 。
+    pinyin: ''
+  english: The school is closed for a day because of the snow.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 计划
+    pinyin: jì huà
+  - chinese: 在
+    pinyin: zài
+  - chinese: 放假
+    pinyin: fàng jià
+  - chinese: 时
+    pinyin: shí
+  - chinese: 去
+    pinyin: qù
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 。
+    pinyin: ''
+  english: We plan to travel during the vacation.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 放假
+    pinyin: fàng jià
+  - chinese: 时
+    pinyin: shí
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What do you usually do during your vacation?
+
+- segments:
+  - chinese: 因为
+    pinyin: yīn wèi
+  - chinese: 生病
+    pinyin: shēng bìng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 她
+    pinyin: tā
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 了
+    pinyin: le
+  - chinese: 三
+    pinyin: sān
+  - chinese: 天
+    pinyin: tiān
+  - chinese: 假
+    pinyin: jià
+  - chinese: 。
+    pinyin: ''
+  english: She took three days off because of illness.
+
+- segments:
+  - chinese: 非常
+    pinyin: fēi cháng
+  - chinese: 感谢
+    pinyin: gǎn xiè
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 来
+    pinyin: lái
+  - chinese: 。
+    pinyin: ''
+  english: Thank you very much for coming.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 非常
+    pinyin: fēi cháng
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 。
+    pinyin: ''
+  english: It's extremely cold today.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 非常
+    pinyin: fēi cháng
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 。
+    pinyin: ''
+  english: This dress is very beautiful.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 非常
+    pinyin: fēi cháng
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 意大利
+    pinyin: Yì dà lì
+  - chinese: 面
+    pinyin: miàn
+  - chinese: 。
+    pinyin: ''
+  english: She likes eating Italian pasta very much.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 非常
+    pinyin: fēi cháng
+  - chinese: 有趣
+    pinyin: yǒu qù
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一口气
+    pinyin: yī kǒu qì
+  - chinese: 读
+    pinyin: dú
+  - chinese: 完
+    pinyin: wán
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: This book is extremely interesting, I read it in one breath.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 事
+    pinyin: shì
+  - chinese: 干
+    pinyin: gān
+  - chinese: 坏
+    pinyin: huài
+  - chinese: 了
+    pinyin: le
+  - chinese: ？
+    pinyin: ''
+  english: How did you mess this thing up?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 干
+    pinyin: gān
+  - chinese: 得
+    pinyin: de
+  - chinese: 这么
+    pinyin: zhè me
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: ？
+    pinyin: ''
+  english: How did you manage to do this job so well?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 别管
+    pinyin: bié guǎn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 干
+    pinyin: gàn
+  - chinese: 。
+    pinyin: ''
+  english: Don't worry, I can handle it.
+
+- segments:
+  - chinese: 关上
+    pinyin: guān shàng
+  - chinese: 窗户
+    pinyin: chuāng hu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 觉得
+    pinyin: jué de
+  - chinese: 有点
+    pinyin: yǒu diǎn
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 。
+    pinyin: ''
+  english: Close the window, I feel a bit cold.
+
+- segments:
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: 前
+    pinyin: qián
+  - chinese: ，
+    pinyin: ''
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 关上
+    pinyin: guān shàng
+  - chinese: 手机
+    pinyin: shǒu jī
+  - chinese: 。
+    pinyin: ''
+  english: Please turn off your phone before dinner.
+
+- segments:
+  - chinese: 关上
+    pinyin: guān shàng
+  - chinese: 盒子
+    pinyin: hé zi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不
+    pinyin: bù
+  - chinese: 要
+    pinyin: yào
+  - chinese: 让
+    pinyin: ràng
+  - chinese: 孩子们
+    pinyin: hái zi men
+  - chinese: 看到
+    pinyin: kàn dào
+  - chinese: 。
+    pinyin: ''
+  english: Close the box, don't let the kids see it.
+
+- segments:
+  - chinese: 关上
+    pinyin: guān shàng
+  - chinese: 灯
+    pinyin: dēng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 睡觉
+    pinyin: shuì jiào
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: Turn off the lights, we're ready to sleep.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 从来
+    pinyin: cóng lái
+  - chinese: 没
+    pinyin: méi
+  - chinese: 去
+    pinyin: qù
+  - chinese: 过
+    pinyin: guò
+  - chinese: 国外
+    pinyin: guó wài
+  - chinese: 。
+    pinyin: ''
+  english: I've never been abroad.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 决定
+    pinyin: jué dìng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 国外
+    pinyin: guó wài
+  - chinese: 度
+    pinyin: dù
+  - chinese: 蜜月
+    pinyin: mì yuè
+  - chinese: 。
+    pinyin: ''
+  english: They decided to spend their honeymoon abroad.
+
+- segments:
+  - chinese: 国外
+    pinyin: guó wài
+  - chinese: 的
+    pinyin: de
+  - chinese: 生活
+    pinyin: shēng huó
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 不同
+    pinyin: bù tóng
+  - chinese: 。
+    pinyin: ''
+  english: Life abroad is very different.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 哪
+    pinyin: nǎ
+  - chinese: 个
+    pinyin: gè
+  - chinese: 国外
+    pinyin: guó wài
+  - chinese: 城市
+    pinyin: chéng shì
+  - chinese: ？
+    pinyin: ''
+  english: Which foreign city do you most want to visit?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 国外
+    pinyin: guó wài
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 了
+    pinyin: le
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 年
+    pinyin: nián
+  - chinese: 。
+    pinyin: ''
+  english: He has been working overseas for two years.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 花
+    pinyin: huā
+  - chinese: 。
+    pinyin: ''
+  english: You shouldn't eat flowers.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 回家
+    pinyin: huí jiā
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I'm going home.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 回家
+    pinyin: huí jiā
+  - chinese: ？
+    pinyin: ''
+  english: When are you going home?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一
+    pinyin: yī
+  - chinese: 放学
+    pinyin: fàng xué
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 回家
+    pinyin: huí jiā
+  - chinese: 。
+    pinyin: ''
+  english: I go home right after school.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 决定
+    pinyin: jué dìng
+  - chinese: 早点
+    pinyin: zǎo diǎn
+  - chinese: 回家
+    pinyin: huí jiā
+  - chinese: 。
+    pinyin: ''
+  english: They decided to go home early.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 和
+    pinyin: hé
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 回家
+    pinyin: huí jiā
+  - chinese: 。
+    pinyin: ''
+  english: You can come home with me.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 一
+    pinyin: yī
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 机票
+    pinyin: jī piào
+  - chinese: 。
+    pinyin: ''
+  english: I need to buy an airplane ticket.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 机票
+    pinyin: jī piào
+  - chinese: ？
+    pinyin: ''
+  english: When did you buy the airplane ticket?
+
+- segments:
+  - chinese: 机票
+    pinyin: jī piào
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 贵
+    pinyin: guì
+  - chinese: ，
+    pinyin: ''
+  - chinese: 所以
+    pinyin: suǒ yǐ
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 决定
+    pinyin: jué dìng
+  - chinese: 不
+    pinyin: bù
+  - chinese: 去
+    pinyin: qù
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: The plane tickets are very expensive, so we decided not to go.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 机票
+    pinyin: jī piào
+  - chinese: 打印
+    pinyin: dǎ yìn
+  - chinese: 出来
+    pinyin: chū lái
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Print out your plane ticket.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 介绍
+    pinyin: jiè shào
+  - chinese: 一下
+    pinyin: yī xià
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 自己
+    pinyin: zì jǐ
+  - chinese: 。
+    pinyin: ''
+  english: Please introduce yourself to me.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 介绍
+    pinyin: jiè shào
+  - chinese: 了
+    pinyin: le
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 。
+    pinyin: ''
+  english: She introduced me to her friends.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 介绍
+    pinyin: jiè shào
+  - chinese: 一下
+    pinyin: yī xià
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 城市
+    pinyin: chéng shì
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you give me an introduction to this city?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 是
+    pinyin: shì
+  - chinese: 关于
+    pinyin: guān yú
+  - chinese: 中国
+    pinyin: Zhōng guó
+  - chinese: 历史
+    pinyin: lì shǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 介绍
+    pinyin: jiè shào
+  - chinese: 。
+    pinyin: ''
+  english: This book is an introduction to Chinese history.
+
+- segments:
+  - chinese: 经理
+    pinyin: jīng lǐ
+  - chinese: 介绍
+    pinyin: jiè shào
+  - chinese: 了
+    pinyin: le
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 员工
+    pinyin: yuán gōng
+  - chinese: 。
+    pinyin: ''
+  english: The manager introduced the new staff member.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 进
+    pinyin: jìn
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 栋
+    pinyin: dòng
+  - chinese: 楼
+    pinyin: lóu
+  - chinese: ？
+    pinyin: ''
+  english: How do you enter this building?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 没
+    pinyin: méi
+  - chinese: 看到
+    pinyin: kàn dào
+  - chinese: 他
+    pinyin: tā
+  - chinese: ？
+    pinyin: ''
+  english: How did you not see him?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 看到
+    pinyin: kàn dào
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 牵
+    pinyin: qiān
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 手
+    pinyin: shǒu
+  - chinese: 。
+    pinyin: ''
+  english: I saw them holding hands.
+
+- segments:
+  - chinese: 楼上
+    pinyin: lóu shàng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 图书馆
+    pinyin: tú shū guǎn
+  - chinese: 。
+    pinyin: ''
+  english: There is a library upstairs.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 楼上
+    pinyin: lóu shàng
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you go upstairs and have a look?
+
+- segments:
+  - chinese: 楼上
+    pinyin: lóu shàng
+  - chinese: 的
+    pinyin: de
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 空
+    pinyin: kòng
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 。
+    pinyin: ''
+  english: The room upstairs is vacant.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 包
+    pinyin: bāo
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 到
+    pinyin: dào
+  - chinese: 楼上
+    pinyin: lóu shàng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you take this bag upstairs?
+
+- segments:
+  - chinese: 楼上
+    pinyin: lóu shàng
+  - chinese: 的
+    pinyin: de
+  - chinese: 邻居
+    pinyin: lín jū
+  - chinese: 在
+    pinyin: zài
+  - chinese: 搞
+    pinyin: gǎo
+  - chinese: 装修
+    pinyin: zhuāng xiū
+  - chinese: 。
+    pinyin: ''
+  english: The upstairs neighbor is doing renovations.
+
+- segments:
+  - chinese: 楼下
+    pinyin: lóu xià
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 书店
+    pinyin: shū diàn
+  - chinese: 。
+    pinyin: ''
+  english: There is a bookstore downstairs.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 路上
+    pinyin: lù shang
+  - chinese: 打
+    pinyin: dǎ
+  - chinese: 电话
+    pinyin: diàn huà
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 。
+    pinyin: ''
+  english: He called me on the way.
+
+- segments:
+  - chinese: 慢
+    pinyin: màn
+  - chinese: 点儿
+    pinyin: diǎn r
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 不
+    pinyin: bù
+  - chinese: 急
+    pinyin: jí
+  - chinese: 。
+    pinyin: ''
+  english: Walk slowly, we're not in a hurry.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 只
+    pinyin: zhǐ
+  - chinese: 鸟
+    pinyin: niǎo
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 美丽
+    pinyin: měi lì
+  - chinese: 的
+    pinyin: de
+  - chinese: 毛
+    pinyin: máo
+  - chinese: 。
+    pinyin: ''
+  english: This bird has beautiful feathers.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 毛
+    pinyin: máo
+  - chinese: ，
+    pinyin: ''
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 一些
+    pinyin: yī xiē
+  - chinese: 糖果
+    pinyin: táng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: Here's 20 cents, buy some candy.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 枚
+    pinyin: méi
+  - chinese: 鸡蛋
+    pinyin: jī dàn
+  - chinese: 卖
+    pinyin: mài
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 毛
+    pinyin: máo
+  - chinese: 钱
+    pinyin: qián
+  - chinese: 。
+    pinyin: ''
+  english: This egg costs 20 cents.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 钱包
+    pinyin: qián bāo
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 三
+    pinyin: sān
+  - chinese: 毛
+    pinyin: máo
+  - chinese: 钱
+    pinyin: qián
+  - chinese: 。
+    pinyin: ''
+  english: I have 30 cents in my wallet.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 男朋友
+    pinyin: nán péng you
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 帅
+    pinyin: shuài
+  - chinese: 。
+    pinyin: ''
+  english: My boyfriend is very handsome.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 已经
+    pinyin: yǐ jīng
+  - chinese: 交往
+    pinyin: jiāo wǎng
+  - chinese: 了
+    pinyin: le
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 年
+    pinyin: nián
+  - chinese: 的
+    pinyin: de
+  - chinese: 男朋友
+    pinyin: nán péng you
+  - chinese: 。
+    pinyin: ''
+  english: They have been dating as boyfriends for two years.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 和
+    pinyin: hé
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 男朋友
+    pinyin: nán péng you
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 周
+    pinyin: zhōu
+  - chinese: 去
+    pinyin: qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 场
+    pinyin: chǎng
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: My boyfriend and I went to see a movie last week.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 男朋友
+    pinyin: nán péng you
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 她
+    pinyin: tā
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: 束
+    pinyin: shù
+  - chinese: 花
+    pinyin: huā
+  - chinese: 。
+    pinyin: ''
+  english: Her boyfriend bought her a bouquet of flowers.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 希望
+    pinyin: xī wàng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 天
+    pinyin: tiān
+  - chinese: 找到
+    pinyin: zhǎo dào
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 男朋友
+    pinyin: nán péng you
+  - chinese: 。
+    pinyin: ''
+  english: I hope to find a great boyfriend someday.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 男朋友
+    pinyin: nán péng you
+  - chinese: 是
+    pinyin: shì
+  - chinese: 医生
+    pinyin: yī shēng
+  - chinese: 。
+    pinyin: ''
+  english: Her boyfriend is a doctor.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 男朋友
+    pinyin: nán péng you
+  - chinese: 是
+    pinyin: shì
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 。
+    pinyin: ''
+  english: Her boyfriend is a teacher.
+
+- segments:
+  - chinese: 跑
+    pinyin: pǎo
+  - chinese: 得
+    pinyin: de
+  - chinese: 快
+    pinyin: kuài
+  - chinese: 点儿
+    pinyin: diǎn r
+  - chinese: ！
+    pinyin: ''
+  - chinese: 车子
+    pinyin: chē zi
+  - chinese: 来
+    pinyin: lái
+  - chinese: 了
+    pinyin: le
+  - chinese: ！
+    pinyin: ''
+  english: Run faster! The car is coming!
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 跑
+    pinyin: pǎo
+  - chinese: 去
+    pinyin: qù
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 些
+    pinyin: xiē
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 。
+    pinyin: ''
+  english: I'll quickly go to the store to buy some things.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 跑
+    pinyin: pǎo
+  - chinese: 去
+    pinyin: qù
+  - chinese: 厨房
+    pinyin: chú fáng
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 晚餐
+    pinyin: wǎn cān
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: She went to the kitchen to make dinner.
+
+- segments:
+  - chinese: 别
+    pinyin: bié
+  - chinese: 跑
+    pinyin: pǎo
+  - chinese: ！
+    pinyin: ''
+  - chinese: 留
+    pinyin: liú
+  - chinese: 下来
+    pinyin: xià lai
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 战斗
+    pinyin: zhàn dòu
+  - chinese: ！
+    pinyin: ''
+  english: Don't run! Stay and fight me!
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 早上
+    pinyin: zǎo shang
+  - chinese: 七
+    pinyin: qī
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 起床
+    pinyin: qǐ chuáng
+  - chinese: 。
+    pinyin: ''
+  english: I usually get up at seven in the morning.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 起床
+    pinyin: qǐ chuáng
+  - chinese: ？
+    pinyin: ''
+  english: What time do you get up?
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 起床
+    pinyin: qǐ chuáng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 晚
+    pinyin: wǎn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 已经
+    pinyin: yǐ jīng
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I woke up very late today, it's already nine o'clock.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 得
+    pinyin: děi
+  - chinese: 早点
+    pinyin: zǎo diǎn
+  - chinese: 起床
+    pinyin: qǐ chuáng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 这样
+    pinyin: zhè yàng
+  - chinese: 才
+    pinyin: cái
+  - chinese: 不
+    pinyin: bù
+  - chinese: 会
+    pinyin: huì
+  - chinese: 迟到
+    pinyin: chí dào
+  - chinese: 。
+    pinyin: ''
+  english: You need to get up early so that you won't be late.
+
+- segments:
+  - chinese: 起床
+    pinyin: qǐ chuáng
+  - chinese: 后
+    pinyin: hòu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 先
+    pinyin: xiān
+  - chinese: 刷牙
+    pinyin: shuā yá
+  - chinese: 洗脸
+    pinyin: xǐ liǎn
+  - chinese: 。
+    pinyin: ''
+  english: After getting up, I brush my teeth and wash my face first.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 一
+    pinyin: yī
+  - chinese: 辆
+    pinyin: liàng
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 汽车
+    pinyin: qì chē
+  - chinese: 。
+    pinyin: ''
+  english: I want to buy a new car.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 汽车
+    pinyin: qì chē
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 老
+    pinyin: lǎo
+  - chinese: ，
+    pinyin: ''
+  - chinese: 经常
+    pinyin: jīng cháng
+  - chinese: 出
+    pinyin: chū
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 。
+    pinyin: ''
+  english: His car is very old and often has problems.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 开
+    pinyin: kāi
+  - chinese: 汽车
+    pinyin: qì chē
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you know how to drive a car?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 汽车
+    pinyin: qì chē
+  - chinese: 是
+    pinyin: shì
+  - chinese: 红色
+    pinyin: hóng sè
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: My car is red.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 汽车
+    pinyin: qì chē
+  - chinese: 去
+    pinyin: qù
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 。
+    pinyin: ''
+  english: They went on a trip by car.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 俩
+    pinyin: liǎ
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 间
+    pinyin: jiān
+  - chinese: 。
+    pinyin: ''
+  english: They were sitting on either side of me.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 休息
+    pinyin: xiū xi
+  - chinese: 一
+    pinyin: yī
+  - chinese: 间
+    pinyin: jiān
+  - chinese: 。
+    pinyin: ''
+  english: We took a break during the coffee break.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 间
+    pinyin: jiān
+  - chinese: 屋子
+    pinyin: wū zi
+  - chinese: 比
+    pinyin: bǐ
+  - chinese: 那
+    pinyin: nà
+  - chinese: 间
+    pinyin: jiān
+  - chinese: 宽敞
+    pinyin: kuān chang
+  - chinese: 。
+    pinyin: ''
+  english: This room is more spacious than that one.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 日期
+    pinyin: rì qī
+  - chinese: 间
+    pinyin: jiān
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 空闲
+    pinyin: kòng xián
+  - chinese: 的
+    pinyin: de
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 。
+    pinyin: ''
+  english: I don't have free time between these two dates.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 俩
+    pinyin: liǎ
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 在
+    pinyin: zài
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 旁边
+    pinyin: páng biān
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 感到
+    pinyin: gǎn dào
+  - chinese: 不
+    pinyin: bù
+  - chinese: 舒服
+    pinyin: shū fu
+  - chinese: 。
+    pinyin: ''
+  english: I felt uncomfortable with them sitting on my sides.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 间
+    pinyin: jiān
+  - chinese: 房子
+    pinyin: fáng zi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 大
+    pinyin: dà
+  - chinese: 。
+    pinyin: ''
+  english: This room is very big.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 间
+    pinyin: jiān
+  - chinese: 房
+    pinyin: fáng
+  - chinese: 一样
+    pinyin: yī yàng
+  - chinese: 大
+    pinyin: dà
+  - chinese: 。
+    pinyin: ''
+  english: These two rooms are the same size.
+
+- segments:
+  - chinese: 教室
+    pinyin: jiào shì
+  - chinese: 间
+    pinyin: jiān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小
+    pinyin: xiǎo
+  - chinese: 花园
+    pinyin: huā yuán
+  - chinese: 。
+    pinyin: ''
+  english: There is a small garden between the classrooms.
+
+- segments:
+  - chinese: 今年
+    pinyin: jīn nián
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 多
+    pinyin: duō
+  - chinese: 大
+    pinyin: dà
+  - chinese: 了
+    pinyin: le
+  - chinese: ？
+    pinyin: ''
+  english: How old are you this year?
+
+- segments:
+  - chinese: 今年
+    pinyin: jīn nián
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 打算
+    pinyin: dǎ suàn
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 。
+    pinyin: ''
+  english: I plan to travel this year.
+
+- segments:
+  - chinese: 今年
+    pinyin: jīn nián
+  - chinese: 夏天
+    pinyin: xià tiān
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 凉快
+    pinyin: liáng kuai
+  - chinese: 。
+    pinyin: ''
+  english: This summer is quite cool.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 今年
+    pinyin: jīn nián
+  - chinese: 已经
+    pinyin: yǐ jīng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 过
+    pinyin: guò
+  - chinese: 中国
+    pinyin: Zhōng guó
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: You have already been to China this year.
+
+- segments:
+  - chinese: 今年
+    pinyin: jīn nián
+  - chinese: 圣诞节
+    pinyin: Shèng dàn jié
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 打算
+    pinyin: dǎ suàn
+  - chinese: 去
+    pinyin: qù
+  - chinese: 滑雪
+    pinyin: huá xuě
+  - chinese: 。
+    pinyin: ''
+  english: We plan to go skiing during Christmas this year.
+
+- segments:
+  - chinese: 上课
+    pinyin: shàng kè
+  - chinese: 时
+    pinyin: shí
+  - chinese: ，
+    pinyin: ''
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 们
+    pinyin: men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 教学楼
+    pinyin: jiào xué lóu
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 。
+    pinyin: ''
+  english: During class hours, the students are in the academic building.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 进去
+    pinyin: jìn qù
+  - chinese: 了
+    pinyin: le
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 。
+    pinyin: ''
+  english: They went into the store.
+
+- segments:
+  - chinese: 进去
+    pinyin: jìn qù
+  - chinese: 前
+    pinyin: qián
+  - chinese: ，
+    pinyin: ''
+  - chinese: 记得
+    pinyin: jì de
+  - chinese: 打
+    pinyin: dǎ
+  - chinese: 电话
+    pinyin: diàn huà
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 。
+    pinyin: ''
+  english: Remember to call me before you go in.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 口
+    pinyin: kǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 渴
+    pinyin: kě
+  - chinese: 。
+    pinyin: ''
+  english: I am thirsty.
+
+- segments:
+  - chinese: 跑
+    pinyin: pǎo
+  - chinese: 马拉松
+    pinyin: mǎ lā sōng
+  - chinese: 后
+    pinyin: hòu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 运动员
+    pinyin: yùn dòng yuán
+  - chinese: 们
+    pinyin: men
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 渴
+    pinyin: kě
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: The athletes were all thirsty after running the marathon.
+
+- segments:
+  - chinese: 在
+    pinyin: zài
+  - chinese: 炎热
+    pinyin: yán rè
+  - chinese: 的
+    pinyin: de
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 中
+    pinyin: zhōng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 记
+    pinyin: jì
+  - chinese: 得
+    pinyin: de
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不
+    pinyin: bù
+  - chinese: 要
+    pinyin: yào
+  - chinese: 等到
+    pinyin: děng dào
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 渴
+    pinyin: kě
+  - chinese: 了
+    pinyin: le
+  - chinese: 才
+    pinyin: cái
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 。
+    pinyin: ''
+  english: Remember to drink water in hot weather; don't wait until you're thirsty.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 对
+    pinyin: duì
+  - chinese: 知识
+    pinyin: zhī shi
+  - chinese: 的
+    pinyin: de
+  - chinese: 渴望
+    pinyin: kě wàng
+  - chinese: 是
+    pinyin: shì
+  - chinese: 无
+    pinyin: wú
+  - chinese: 止境
+    pinyin: zhǐ jìng
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: Her thirst for knowledge is insatiable.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 让
+    pinyin: ràng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 渴望
+    pinyin: kě wàng
+  - chinese: 读
+    pinyin: dú
+  - chinese: 更
+    pinyin: gèng
+  - chinese: 多
+    pinyin: duō
+  - chinese: 类似
+    pinyin: lèi sì
+  - chinese: 的
+    pinyin: de
+  - chinese: 作品
+    pinyin: zuò pǐn
+  - chinese: 。
+    pinyin: ''
+  english: This book made me thirsty to read more works like it.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 用
+    pinyin: yòng
+  - chinese: 口
+    pinyin: kǒu
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 出
+    pinyin: chū
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 想法
+    pinyin: xiǎng fǎ
+  - chinese: 。
+    pinyin: ''
+  english: She expressed her thoughts verbally.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 杯子
+    pinyin: bēi zi
+  - chinese: 口
+    pinyin: kǒu
+  - chinese: 太
+    pinyin: tài
+  - chinese: 窄
+    pinyin: zhǎi
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 没法
+    pinyin: méi fǎ
+  - chinese: 用
+    pinyin: yòng
+  - chinese: 它
+    pinyin: tā
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 汤
+    pinyin: tāng
+  - chinese: 。
+    pinyin: ''
+  english: The opening of this cup is too narrow; I can't drink soup from it.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 口
+    pinyin: kǒu
+  - chinese: 井
+    pinyin: jǐng
+  - chinese: 已经
+    pinyin: yǐ jīng
+  - chinese: 干
+    pinyin: gān
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: This well has run dry.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 块
+    pinyin: kuài
+  - chinese: 巧克力
+    pinyin: qiǎo kè lì
+  - chinese: 太
+    pinyin: tài
+  - chinese: 甜
+    pinyin: tián
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: This piece of chocolate is too sweet.
+
+- segments:
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 三
+    pinyin: sān
+  - chinese: 块
+    pinyin: kuài
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: There are three apples on the table.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 片
+    pinyin: piàn
+  - chinese: 面包
+    pinyin: miàn bāo
+  - chinese: 。
+    pinyin: ''
+  english: I want two slices of bread.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 的
+    pinyin: de
+  - chinese: 路
+    pinyin: lù
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you know the way to the park?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 图书馆
+    pinyin: tú shū guǎn
+  - chinese: 的
+    pinyin: de
+  - chinese: 路
+    pinyin: lù
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you know the way to the library?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 在
+    pinyin: zài
+  - chinese: 红绿灯
+    pinyin: hóng lǜ dēng
+  - chinese: 路口
+    pinyin: lù kǒu
+  - chinese: 左转
+    pinyin: zuǒ zhuǎn
+  - chinese: 。
+    pinyin: ''
+  english: You will turn left at the traffic light intersection.
+
+- segments:
+  - chinese: 过
+    pinyin: guò
+  - chinese: 了
+    pinyin: le
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 路口
+    pinyin: lù kǒu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 会
+    pinyin: huì
+  - chinese: 看到
+    pinyin: kàn dào
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 的
+    pinyin: de
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 。
+    pinyin: ''
+  english: After passing that intersection, you will see our store.
+
+- segments:
+  - chinese: 在
+    pinyin: zài
+  - chinese: 繁忙
+    pinyin: fán máng
+  - chinese: 的
+    pinyin: de
+  - chinese: 路口
+    pinyin: lù kǒu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 行人
+    pinyin: xíng rén
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 小心
+    pinyin: xiǎo xīn
+  - chinese: 地
+    pinyin: de
+  - chinese: 过
+    pinyin: guò
+  - chinese: 马路
+    pinyin: mǎ lù
+  - chinese: 。
+    pinyin: ''
+  english: At busy intersections, pedestrians need to cross the road carefully.
+
+- segments:
+  - chinese: 路口
+    pinyin: lù kǒu
+  - chinese: 发生
+    pinyin: fā shēng
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 起
+    pinyin: qǐ
+  - chinese: 车祸
+    pinyin: chē huò
+  - chinese: 。
+    pinyin: ''
+  english: A traffic accident occurred at the intersection.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 下
+    pinyin: xià
+  - chinese: 个
+    pinyin: gè
+  - chinese: 路口
+    pinyin: lù kǒu
+  - chinese: 找到
+    pinyin: zhǎo dào
+  - chinese: 一
+    pinyin: yī
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 便利店
+    pinyin: biàn lì diàn
+  - chinese: 。
+    pinyin: ''
+  english: You can find a convenience store at the next intersection.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 的
+    pinyin: de
+  - chinese: 饭店
+    pinyin: fàn diàn
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 在
+    pinyin: zài
+  - chinese: 路口
+    pinyin: lù kǒu
+  - chinese: 。
+    pinyin: ''
+  english: My favorite restaurant is right at the road intersection.
+
+- segments:
+  - chinese: 孩子
+    pinyin: hái zi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不
+    pinyin: bù
+  - chinese: 要
+    pinyin: yào
+  - chinese: 在
+    pinyin: zài
+  - chinese: 马路
+    pinyin: mǎ lù
+  - chinese: 边
+    pinyin: biān
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 。
+    pinyin: ''
+  english: Child, don't play by the roadside.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 没什么
+    pinyin: méi shén me
+  - chinese: 事
+    pinyin: shì
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 。
+    pinyin: ''
+  english: I have nothing to do today.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 门票
+    pinyin: mén piào
+  - chinese: 。
+    pinyin: ''
+  english: I will buy two admission tickets for the cinema.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 门票
+    pinyin: mén piào
+  - chinese: 在
+    pinyin: zài
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 包包
+    pinyin: bāo bāo
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 。
+    pinyin: ''
+  english: My cinema admission ticket is in my bag.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 书
+    pinyin: shū
+  - chinese: 拿
+    pinyin: ná
+  - chinese: 起来
+    pinyin: qi lai
+  - chinese: 。
+    pinyin: ''
+  english: Pick up the book.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 开始
+    pinyin: kāi shǐ
+  - chinese: 跑
+    pinyin: pǎo
+  - chinese: 起来
+    pinyin: qi lai
+  - chinese: 。
+    pinyin: ''
+  english: They started running.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 请假
+    pinyin: qǐng jià
+  - chinese: 。
+    pinyin: ''
+  english: I'll take leave tomorrow.
+
+- segments:
+  - chinese: 因为
+    pinyin: yīn wèi
+  - chinese: 生病
+    pinyin: shēng bìng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 她
+    pinyin: tā
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 请假
+    pinyin: qǐng jià
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: Because she's sick, she took leave today.
+
+- segments:
+  - chinese: 去年
+    pinyin: qù nián
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 了
+    pinyin: le
+  - chinese: 中国
+    pinyin: Zhōng guó
+  - chinese: 。
+    pinyin: ''
+  english: I went to China last year.
+
+- segments:
+  - chinese: 去年
+    pinyin: qù nián
+  - chinese: 比
+    pinyin: bǐ
+  - chinese: 今年
+    pinyin: jīn nián
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 。
+    pinyin: ''
+  english: Last year was colder than this year.
+
+- segments:
+  - chinese: 去年
+    pinyin: qù nián
+  - chinese: 的
+    pinyin: de
+  - chinese: 销售
+    pinyin: xiāo shòu
+  - chinese: 额
+    pinyin: é
+  - chinese: 比
+    pinyin: bǐ
+  - chinese: 前年
+    pinyin: qián nián
+  - chinese: 高
+    pinyin: gāo
+  - chinese: 。
+    pinyin: ''
+  english: Last year's sales were higher than the year before.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 去年
+    pinyin: qù nián
+  - chinese: 有没有
+    pinyin: yǒu méi yǒu
+  - chinese: 去
+    pinyin: qù
+  - chinese: 过
+    pinyin: guò
+  - chinese: 日本
+    pinyin: Rì běn
+  - chinese: ？
+    pinyin: ''
+  english: Did you go to Japan last year?
+
+- segments:
+  - chinese: 去年
+    pinyin: qù nián
+  - chinese: 的
+    pinyin: de
+  - chinese: 生日
+    pinyin: shēng rì
+  - chinese: 派对
+    pinyin: pài duì
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 成功
+    pinyin: chéng gōng
+  - chinese: 。
+    pinyin: ''
+  english: Last year's birthday party was a success.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 早上
+    pinyin: zǎo shang
+  - chinese: 八
+    pinyin: bā
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 上班
+    pinyin: shàng bān
+  - chinese: 。
+    pinyin: ''
+  english: I go to work every morning at eight o'clock.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 半
+    pinyin: bàn
+  - chinese: 上班
+    pinyin: shàng bān
+  - chinese: 。
+    pinyin: ''
+  english: She usually goes to work at nine-thirty.
+
+- segments:
+  - chinese: 上班
+    pinyin: shàng bān
+  - chinese: 路上
+    pinyin: lù shang
+  - chinese: 交通
+    pinyin: jiāo tōng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 拥挤
+    pinyin: yōng jǐ
+  - chinese: 。
+    pinyin: ''
+  english: The traffic is very congested during the commute to work.
+
+- segments:
+  - chinese: 因为
+    pinyin: yīn wèi
+  - chinese: 下
+    pinyin: xià
+  - chinese: 大雨
+    pinyin: dà yǔ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 所以
+    pinyin: suǒ yǐ
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 上班
+    pinyin: shàng bān
+  - chinese: 迟到
+    pinyin: chí dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: Because of the heavy rain, I was late for work.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 灵活
+    pinyin: líng huó
+  - chinese: 地
+    pinyin: de
+  - chinese: 安排
+    pinyin: ān pái
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 上班
+    pinyin: shàng bān
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you flexibly arrange your work hours?
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 早上
+    pinyin: zǎo shang
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 上班
+    pinyin: shàng bān
+  - chinese: 。
+    pinyin: ''
+  english: She goes to work at nine in the morning.
+
+- segments:
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 的
+    pinyin: de
+  - chinese: 上边
+    pinyin: shàng bian
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 脏
+    pinyin: zāng
+  - chinese: 。
+    pinyin: ''
+  english: The top of the table is dirty.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 张
+    pinyin: zhāng
+  - chinese: 纸
+    pinyin: zhǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 上边
+    pinyin: shàng bian
+  - chinese: 是
+    pinyin: shì
+  - chinese: 空白
+    pinyin: kòng bái
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: The top part of this paper is blank.
+
+- segments:
+  - chinese: 盒子
+    pinyin: hé zi
+  - chinese: 的
+    pinyin: de
+  - chinese: 上边
+    pinyin: shàng bian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 个
+    pinyin: gè
+  - chinese: 按钮
+    pinyin: àn niǔ
+  - chinese: 。
+    pinyin: ''
+  english: There is a button on the top of the box.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 上午
+    pinyin: shàng wǔ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 计划
+    pinyin: jì huà
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you have any plans for the morning?
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 上午
+    pinyin: shàng wǔ
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 开会
+    pinyin: kāi huì
+  - chinese: 。
+    pinyin: ''
+  english: They have a meeting at nine in the morning.
+
+- segments:
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 在
+    pinyin: zài
+  - chinese: 上午
+    pinyin: shàng wǔ
+  - chinese: 十
+    pinyin: shí
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 开门
+    pinyin: kāi mén
+  - chinese: 。
+    pinyin: ''
+  english: The store opens at ten in the morning.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 上午
+    pinyin: shàng wǔ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 忙
+    pinyin: máng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 下午
+    pinyin: xià wǔ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 空
+    pinyin: kòng
+  - chinese: 。
+    pinyin: ''
+  english: I'm busy in the morning, but I'm free in the afternoon.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 上午
+    pinyin: shàng wǔ
+  - chinese: 或
+    pinyin: huò
+  - chinese: 下午
+    pinyin: xià wǔ
+  - chinese: 任何
+    pinyin: rèn hé
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 来访
+    pinyin: lái fǎng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 。
+    pinyin: ''
+  english: You can visit me at any time during the morning or afternoon.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 身体
+    pinyin: shēn tǐ
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Is your body okay?
+
+- segments:
+  - chinese: 因为
+    pinyin: yīn wèi
+  - chinese: 生病
+    pinyin: shēng bìng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 她
+    pinyin: tā
+  - chinese: 不能
+    pinyin: bù néng
+  - chinese: 来
+    pinyin: lái
+  - chinese: 上班
+    pinyin: shàng bān
+  - chinese: 。
+    pinyin: ''
+  english: Because she's sick, she can't come to work.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 在
+    pinyin: zài
+  - chinese: 生病
+    pinyin: shēng bìng
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 多
+    pinyin: duō
+  - chinese: 休息
+    pinyin: xiū xi
+  - chinese: 。
+    pinyin: ''
+  english: You should rest more when you're sick.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 生病
+    pinyin: shēng bìng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I'm sick.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 看起来
+    pinyin: kàn qǐ lai
+  - chinese: 生病
+    pinyin: shēng bìng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: You look sick.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 因为
+    pinyin: yīn wèi
+  - chinese: 生病
+    pinyin: shēng bìng
+  - chinese: 而
+    pinyin: ér
+  - chinese: 缺席
+    pinyin: quē xí
+  - chinese: 。
+    pinyin: ''
+  english: He's absent because he's sick.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 生病
+    pinyin: shēng bìng
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: 要
+    pinyin: yào
+  - chinese: 多
+    pinyin: duō
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 。
+    pinyin: ''
+  english: You should drink more water when you're sick.
+
+- segments:
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 健康
+    pinyin: jiàn kāng
+  - chinese: 的
+    pinyin: de
+  - chinese: 食物
+    pinyin: shí wù
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 帮助
+    pinyin: bāng zhù
+  - chinese: 预防
+    pinyin: yù fáng
+  - chinese: 生病
+    pinyin: shēng bìng
+  - chinese: 。
+    pinyin: ''
+  english: Eating healthy food can help prevent illness.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 是不是
+    pinyin: shì bù shì
+  - chinese: 累
+    pinyin: lèi
+  - chinese: 了
+    pinyin: le
+  - chinese: ？
+    pinyin: ''
+  english: Are you tired?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 是不是
+    pinyin: shì bù shì
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: ？
+    pinyin: ''
+  english: Aren't you going to watch a movie?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 是不是
+    pinyin: shì bù shì
+  - chinese: 忘
+    pinyin: wàng
+  - chinese: 了
+    pinyin: le
+  - chinese: 关
+    pinyin: guān
+  - chinese: 灯
+    pinyin: dēng
+  - chinese: ？
+    pinyin: ''
+  english: Didn't you forget to turn off the lights?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 是不是
+    pinyin: shì bù shì
+  - chinese: 要
+    pinyin: yào
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 那
+    pinyin: nà
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 事情
+    pinyin: shì qing
+  - chinese: ？
+    pinyin: ''
+  english: Aren't you going to talk about that matter?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 是不是
+    pinyin: shì bù shì
+  - chinese: 要
+    pinyin: yào
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 红色
+    pinyin: hóng sè
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: ？
+    pinyin: ''
+  english: Aren't you going to buy that red dress?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 书
+    pinyin: shū
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 书包
+    pinyin: shū bāo
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 。
+    pinyin: ''
+  english: You put the books in your schoolbag.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 书包
+    pinyin: shū bāo
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 它
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 颜色
+    pinyin: yán sè
+  - chinese: 。
+    pinyin: ''
+  english: This schoolbag is very nice, I like its color.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 书包
+    pinyin: shū bāo
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What's in your schoolbag?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 书包
+    pinyin: shū bāo
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 重
+    pinyin: zhòng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 因为
+    pinyin: yīn wèi
+  - chinese: 它
+    pinyin: tā
+  - chinese: 装
+    pinyin: zhuāng
+  - chinese: 了
+    pinyin: le
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: His schoolbag is very heavy because it's filled with a lot of books.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 网上
+    pinyin: wǎng shàng
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 书包
+    pinyin: shū bāo
+  - chinese: 。
+    pinyin: ''
+  english: You can buy a schoolbag online.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 从
+    pinyin: cóng
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 棵
+    pinyin: kē
+  - chinese: 树
+    pinyin: shù
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 摘
+    pinyin: zhāi
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: You can pick apples from this tree.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 送
+    pinyin: sòng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 回家
+    pinyin: huí jiā
+  - chinese: 。
+    pinyin: ''
+  english: I'll take you home.
+
+- segments:
+  - chinese: 快递员
+    pinyin: kuài dì yuán
+  - chinese: 送
+    pinyin: sòng
+  - chinese: 包裹
+    pinyin: bāo guǒ
+  - chinese: 。
+    pinyin: ''
+  english: The courier delivers packages.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 送
+    pinyin: sòng
+  - chinese: 孩子
+    pinyin: hái zi
+  - chinese: 上学
+    pinyin: shàng xué
+  - chinese: 。
+    pinyin: ''
+  english: She takes the children to school.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 送
+    pinyin: sòng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 到
+    pinyin: dào
+  - chinese: 机场
+    pinyin: jī chǎng
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you give me a ride to the airport?
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 送
+    pinyin: sòng
+  - chinese: 病人
+    pinyin: bìng rén
+  - chinese: 去
+    pinyin: qù
+  - chinese: 医院
+    pinyin: yī yuàn
+  - chinese: 。
+    pinyin: ''
+  english: They take the patient to the hospital.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 听到
+    pinyin: tīng dào
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 声音
+    pinyin: shēng yīn
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I hear your voice.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 听到
+    pinyin: tīng dào
+  - chinese: 新闻
+    pinyin: xīn wén
+  - chinese: 了
+    pinyin: le
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Have you heard the news?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 听到
+    pinyin: tīng dào
+  - chinese: 一声
+    pinyin: yī shēng
+  - chinese: 巨响
+    pinyin: jù xiǎng
+  - chinese: 。
+    pinyin: ''
+  english: I heard a loud bang.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 听到
+    pinyin: tīng dào
+  - chinese: 门铃
+    pinyin: mén líng
+  - chinese: 响
+    pinyin: xiǎng
+  - chinese: 了
+    pinyin: le
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Did you hear the doorbell ring?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 听到
+    pinyin: tīng dào
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 正在
+    pinyin: zhèng zài
+  - chinese: 争论
+    pinyin: zhēng lùn
+  - chinese: 。
+    pinyin: ''
+  english: I hear them arguing.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 听到
+    pinyin: tīng dào
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 在
+    pinyin: zài
+  - chinese: 电话
+    pinyin: diàn huà
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 笑
+    pinyin: xiào
+  - chinese: 。
+    pinyin: ''
+  english: I heard my mother laugh while talking on the phone.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 问
+    pinyin: wèn
+  - chinese: 了
+    pinyin: le
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What did you ask?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 问
+    pinyin: wèn
+  - chinese: 他
+    pinyin: tā
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I asked him what time it was.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 下班
+    pinyin: xià bān
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I'm off work now.
+
+- segments:
+  - chinese: 下班
+    pinyin: xià bān
+  - chinese: 后
+    pinyin: hòu
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Let's eat together after work.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 下班
+    pinyin: xià bān
+  - chinese: ？
+    pinyin: ''
+  english: What time do you get off work?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 通常
+    pinyin: tōng cháng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 下午
+    pinyin: xià wǔ
+  - chinese: 六
+    pinyin: liù
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 下班
+    pinyin: xià bān
+  - chinese: 。
+    pinyin: ''
+  english: I usually get off work at 6 p.m. in the afternoon.
+
+- segments:
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 下边
+    pinyin: xià bian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 只
+    pinyin: zhī
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 。
+    pinyin: ''
+  english: There is a cat under the table.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 书
+    pinyin: shū
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 椅子
+    pinyin: yǐ zi
+  - chinese: 下边
+    pinyin: xià bian
+  - chinese: 。
+    pinyin: ''
+  english: Put the book under the chair.
+
+- segments:
+  - chinese: 下次
+    pinyin: xià cì
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 来
+    pinyin: lái
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Come to my place next time.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 下次
+    pinyin: xià cì
+  - chinese: 会
+    pinyin: huì
+  - chinese: 记得
+    pinyin: jì de
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 面包
+    pinyin: miàn bāo
+  - chinese: 。
+    pinyin: ''
+  english: I'll remember to buy bread next time.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 下次
+    pinyin: xià cì
+  - chinese: 去
+    pinyin: qù
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 的
+    pinyin: de
+  - chinese: 时候
+    pinyin: shí hou
+  - chinese: ，
+    pinyin: ''
+  - chinese: 叫
+    pinyin: jiào
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 。
+    pinyin: ''
+  english: Call me to go with you the next time you go to the park.
+
+- segments:
+  - chinese: 谢谢
+    pinyin: xiè xie
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: 。
+    pinyin: ''
+  - chinese: 下次
+    pinyin: xià cì
+  - chinese: 让
+    pinyin: ràng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 。
+    pinyin: ''
+  english: Thank you for treating me to dinner. Let me treat you next time.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 回来
+    pinyin: huí lai
+  - chinese: 。
+    pinyin: ''
+  english: I'll be back in two hours.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 份
+    pinyin: fèn
+  - chinese: 作业
+    pinyin: zuò yè
+  - chinese: 需要
+    pinyin: xū yào
+  - chinese: 三
+    pinyin: sān
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: 完成
+    pinyin: wán chéng
+  - chinese: 。
+    pinyin: ''
+  english: This assignment will take three hours to finish.
+
+- segments:
+  - chinese: 火车
+    pinyin: huǒ chē
+  - chinese: 一
+    pinyin: yī
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 班
+    pinyin: bān
+  - chinese: 。
+    pinyin: ''
+  english: The train runs once every hour.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 一
+    pinyin: yī
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: 能
+    pinyin: néng
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 多
+    pinyin: duō
+  - chinese: 远
+    pinyin: yuǎn
+  - chinese: ？
+    pinyin: ''
+  english: How far can you walk in one hour?
+
+- segments:
+  - chinese: 谢谢
+    pinyin: xiè xie
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 事
+    pinyin: shì
+  - chinese: 。
+    pinyin: ''
+  english: Thank you for helping me with this matter.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好看
+    pinyin: hǎo kàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 谢谢
+    pinyin: xiè xie
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 推荐
+    pinyin: tuī jiàn
+  - chinese: 。
+    pinyin: ''
+  english: This book is very interesting. Thank you for recommending it.
+
+- segments:
+  - chinese: 谢谢
+    pinyin: xiè xie
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 下次
+    pinyin: xià cì
+  - chinese: 让
+    pinyin: ràng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 。
+    pinyin: ''
+  english: Thank you for treating me to dinner. Let me treat you next time.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 来
+    pinyin: lái
+  - chinese: 参加
+    pinyin: cān jiā
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 生日
+    pinyin: shēng rì
+  - chinese: 会
+    pinyin: huì
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 开心
+    pinyin: kāi xīn
+  - chinese: 。
+    pinyin: ''
+  - chinese: 谢谢
+    pinyin: xiè xie
+  - chinese: ！
+    pinyin: ''
+  english: I'm very happy that you could come to my birthday party. Thank you!
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 了
+    pinyin: le
+  - chinese: 杯子
+    pinyin: bēi zi
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 一半
+    pinyin: yī bàn
+  - chinese: 的
+    pinyin: de
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 。
+    pinyin: ''
+  english: I drank half of the water in the cup.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一会儿
+    pinyin: yī huì r
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 回来
+    pinyin: huí lai
+  - chinese: 。
+    pinyin: ''
+  english: I'll be back in a moment.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 等
+    pinyin: děng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一会儿
+    pinyin: yī huì r
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 马上
+    pinyin: mǎ shàng
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: Please wait for me for a moment; I'll be ready in a second.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一会儿
+    pinyin: yī huì r
+  - chinese: 要
+    pinyin: yào
+  - chinese: 去
+    pinyin: qù
+  - chinese: 上课
+    pinyin: shàng kè
+  - chinese: ，
+    pinyin: ''
+  - chinese: 现在
+    pinyin: xiàn zài
+  - chinese: 没
+    pinyin: méi
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 聊
+    pinyin: liáo
+  - chinese: 。
+    pinyin: ''
+  english: I have to go to class in a little while, so I don't have time to chat now.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 一会儿
+    pinyin: yī huì r
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 完
+    pinyin: wán
+  - chinese: 饭
+    pinyin: fàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: She'll be done with her meal in a short while.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 一块儿
+    pinyin: yī kuài r
+  - chinese: 去
+    pinyin: qù
+  - chinese: 公园
+    pinyin: gōng yuán
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 。
+    pinyin: ''
+  english: Let's go to the park together.
+
+- segments:
+  - chinese: 这些
+    pinyin: zhè xiē
+  - chinese: 书
+    pinyin: shū
+  - chinese: 要
+    pinyin: yào
+  - chinese: 一块儿
+    pinyin: yī kuài r
+  - chinese: 搬
+    pinyin: bān
+  - chinese: ，
+    pinyin: ''
+  - chinese: 太
+    pinyin: tài
+  - chinese: 重
+    pinyin: zhòng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: We need to move these books together; they're too heavy.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 一块儿
+    pinyin: yī kuài r
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Let's eat together.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 一块儿
+    pinyin: yī kuài r
+  - chinese: 唱歌
+    pinyin: chàng gē
+  - chinese: 的
+    pinyin: de
+  - chinese: 声音
+    pinyin: shēng yīn
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 和谐
+    pinyin: hé xié
+  - chinese: 。
+    pinyin: ''
+  english: Their voices sound very harmonious when they sing together.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 两
+    pinyin: liǎng
+  - chinese: 个
+    pinyin: gè
+  - chinese: 人
+    pinyin: rén
+  - chinese: 长
+    pinyin: zhǎng
+  - chinese: 得
+    pinyin: de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 一样
+    pinyin: yī yàng
+  - chinese: 。
+    pinyin: ''
+  english: Those two people look very similar.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 和
+    pinyin: hé
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 一样
+    pinyin: yī yàng
+  - chinese: 努力
+    pinyin: nǔ lì
+  - chinese: 。
+    pinyin: ''
+  english: I will work hard just like you.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 和
+    pinyin: hé
+  - chinese: 那
+    pinyin: nà
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 差不多
+    pinyin: chà bu duō
+  - chinese: 一样
+    pinyin: yī yàng
+  - chinese: 。
+    pinyin: ''
+  english: This piece of clothing is almost the same as that one.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 也
+    pinyin: yě
+  - chinese: 一样
+    pinyin: yī yàng
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 巧克力
+    pinyin: qiǎo kè lì
+  - chinese: 。
+    pinyin: ''
+  english: I also like chocolate.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 一样
+    pinyin: yī yàng
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 运动
+    pinyin: yùn dòng
+  - chinese: 。
+    pinyin: ''
+  english: They both enjoy sports alike.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 也
+    pinyin: yě
+  - chinese: 一样
+    pinyin: yī yàng
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电影
+    pinyin: diàn yǐng
+  - chinese: 。
+    pinyin: ''
+  english: I also like watching movies.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 和
+    pinyin: hé
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 一样
+    pinyin: yī yàng
+  - chinese: 好好
+    pinyin: hǎo hǎo
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 。
+    pinyin: ''
+  english: I will study hard just like you.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 把
+    pinyin: bǎ
+  - chinese: 书
+    pinyin: shū
+  - chinese: 放
+    pinyin: fàng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 床
+    pinyin: chuáng
+  - chinese: 的
+    pinyin: de
+  - chinese: 一边
+    pinyin: yī biān
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Put the book on one side of the bed.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一边
+    pinyin: yī biān
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 电视
+    pinyin: diàn shì
+  - chinese: 一边
+    pinyin: yī biān
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 茶
+    pinyin: chá
+  - chinese: 。
+    pinyin: ''
+  english: I watch TV while drinking tea.
+
+- segments:
+  - chinese: 书
+    pinyin: shū
+  - chinese: 在
+    pinyin: zài
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 下边
+    pinyin: xià bian
+  - chinese: 。
+    pinyin: ''
+  english: The book is under the table.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 下车
+    pinyin: xià chē
+  - chinese: 时
+    pinyin: shí
+  - chinese: ，
+    pinyin: ''
+  - chinese: 天
+    pinyin: tiān
+  - chinese: 已经
+    pinyin: yǐ jīng
+  - chinese: 黑
+    pinyin: hēi
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: By the time they got off the car, it was already dark.
+
+- segments:
+  - chinese: 有的
+    pinyin: yǒu de
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 读书
+    pinyin: dú shū
+  - chinese: ，
+    pinyin: ''
+  - chinese: 有的
+    pinyin: yǒu de
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 唱歌
+    pinyin: chàng gē
+  - chinese: 。
+    pinyin: ''
+  english: Some students like to read, and others like to sing.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 大学
+    pinyin: dà xué
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 有名
+    pinyin: yǒu míng
+  - chinese: 。
+    pinyin: ''
+  english: My university is famous.
+
+- segments:
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 去
+    pinyin: qù
+  - chinese: 图书馆
+    pinyin: tú shū guǎn
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: Some students went to the library.
+
+- segments:
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 难
+    pinyin: nán
+  - chinese: 。
+    pinyin: ''
+  english: Some questions are very difficult.
+
+- segments:
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 人
+    pinyin: rén
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 冬天
+    pinyin: dōng tiān
+  - chinese: ，
+    pinyin: ''
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 人
+    pinyin: rén
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 夏天
+    pinyin: xià tiān
+  - chinese: 。
+    pinyin: ''
+  english: Some people like winter, and some like summer.
+
+- segments:
+  - chinese: 有些
+    pinyin: yǒu xiē
+  - chinese: 书
+    pinyin: shū
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 贵
+    pinyin: guì
+  - chinese: 。
+    pinyin: ''
+  english: Some books are very expensive.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 再
+    pinyin: zài
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 一
+    pinyin: yī
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 茶
+    pinyin: chá
+  - chinese: 。
+    pinyin: ''
+  english: I'd like one more cup of tea.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 早
+    pinyin: zǎo
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 起床
+    pinyin: qǐ chuáng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I got up early.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 来
+    pinyin: lái
+  - chinese: 得
+    pinyin: de
+  - chinese: 太
+    pinyin: tài
+  - chinese: 早
+    pinyin: zǎo
+  - chinese: 了
+    pinyin: le
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 还
+    pinyin: hái
+  - chinese: 没
+    pinyin: méi
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: You came too early; I'm not ready yet.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 这么
+    pinyin: zhè me
+  - chinese: 早
+    pinyin: zǎo
+  - chinese: 就
+    pinyin: jiù
+  - chinese: 回来
+    pinyin: huí lai
+  - chinese: 了
+    pinyin: le
+  - chinese: ？
+    pinyin: ''
+  english: Why did you come back so early?
+
+- segments:
+  - chinese: 这些
+    pinyin: zhè xiē
+  - chinese: 书
+    pinyin: shū
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: These books are all mine.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 这些
+    pinyin: zhè xiē
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 。
+    pinyin: ''
+  english: I don't like these clothes.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 拿
+    pinyin: ná
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 这些
+    pinyin: zhè xiē
+  - chinese: 箱子
+    pinyin: xiāng zi
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you hold these boxes?
+
+- segments:
+  - chinese: 这些
+    pinyin: zhè xiē
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 聪明
+    pinyin: cōng ming
+  - chinese: 。
+    pinyin: ''
+  english: These students are all very smart.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 不
+    pinyin: bù
+  - chinese: 下
+    pinyin: xià
+  - chinese: 这些
+    pinyin: zhè xiē
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I can't eat all of these dishes.
+
+- segments:
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 真的
+    pinyin: zhēn de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 。
+    pinyin: ''
+  english: The weather is truly cold.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 真的
+    pinyin: zhēn de
+  - chinese: 好看
+    pinyin: hǎo kàn
+  - chinese: ！
+    pinyin: ''
+  english: This dress is really beautiful!
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 真的
+    pinyin: zhēn de
+  - chinese: 不
+    pinyin: bù
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 答案
+    pinyin: dá àn
+  - chinese: 。
+    pinyin: ''
+  english: I genuinely don't know the answer.
+
+- segments:
+  - chinese: 真的
+    pinyin: zhēn de
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 没
+    pinyin: méi
+  - chinese: 说谎
+    pinyin: shuō huǎng
+  - chinese: 。
+    pinyin: ''
+  english: Really, I'm not lying.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 哥哥
+    pinyin: gē ge
+  - chinese: 在
+    pinyin: zài
+  - chinese: 学院
+    pinyin: xué yuàn
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 。
+    pinyin: ''
+  english: My brother studies at the academy.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 弟弟
+    pinyin: dì di
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 中学
+    pinyin: zhōng xué
+  - chinese: 。
+    pinyin: ''
+  english: My younger brother attends middle school.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 车
+    pinyin: chē
+  - chinese: 在
+    pinyin: zài
+  - chinese: 图书馆
+    pinyin: tú shū guǎn
+  - chinese: 旁边
+    pinyin: páng biān
+  - chinese: 。
+    pinyin: ''
+  english: My car is next to the library.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 火车
+    pinyin: huǒ chē
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 唱
+    pinyin: chàng
+  - chinese: 。
+    pinyin: ''
+  english: She sang on the train.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 自己
+    pinyin: zì jǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 里
+    pinyin: lǐ
+  - chinese: 唱
+    pinyin: chàng
+  - chinese: 。
+    pinyin: ''
+  english: She sang in her room.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 从
+    pinyin: cóng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 哥哥
+    pinyin: gē ge
+  - chinese: 那里
+    pinyin: nà li
+  - chinese: 得到
+    pinyin: dé dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I got this book from my older brother.
+
+- segments:
+  - chinese: 这些
+    pinyin: zhè xiē
+  - chinese: 工人
+    pinyin: gōng rén
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 饿
+    pinyin: è
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: These workers are all hungry.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 干净
+    pinyin: gān jìng
+  - chinese: 。
+    pinyin: ''
+  english: Your clothes are very clean.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 大学
+    pinyin: dà xué
+  - chinese: 的
+    pinyin: de
+  - chinese: 东边
+    pinyin: dōng bian
+  - chinese: 。
+    pinyin: ''
+  english: My home is to the east of the university.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 的
+    pinyin: de
+  - chinese: 饭店
+    pinyin: fàn diàn
+  - chinese: 地点
+    pinyin: dì diǎn
+  - chinese: 是
+    pinyin: shì
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: ？
+    pinyin: ''
+  english: What's the location of your favorite restaurant?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 地图
+    pinyin: dì tú
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 找到
+    pinyin: zhǎo dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 的
+    pinyin: de
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 。
+    pinyin: ''
+  english: I found our school on the map.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 地图
+    pinyin: dì tú
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you have a map?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 地图
+    pinyin: dì tú
+  - chinese: 。
+    pinyin: ''
+  english: I'm learning how to read a map.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 动作
+    pinyin: dòng zuò
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 快
+    pinyin: kuài
+  - chinese: 。
+    pinyin: ''
+  english: His actions are very quick.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 能
+    pinyin: néng
+  - chinese: 看到
+    pinyin: kàn dào
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 后边
+    pinyin: hòu bian
+  - chinese: 的
+    pinyin: de
+  - chinese: 人
+    pinyin: rén
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you see the person behind me?
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 应该
+    pinyin: yīng gāi
+  - chinese: 往
+    pinyin: wǎng
+  - chinese: 后边
+    pinyin: hòu bian
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 一点
+    pinyin: yī diǎn
+  - chinese: 。
+    pinyin: ''
+  english: We should move back a little.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 会
+    pinyin: huì
+  - chinese: 回到
+    pinyin: huí dào
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 。
+    pinyin: ''
+  english: I'll be back home tomorrow.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 会
+    pinyin: huì
+  - chinese: 回到
+    pinyin: huí dào
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 。
+    pinyin: ''
+  english: They will return to school.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 花
+    pinyin: huā
+  - chinese: 送
+    pinyin: sòng
+  - chinese: 给
+    pinyin: gěi
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 。
+    pinyin: ''
+  english: I like to buy flowers for my mother.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 看见
+    pinyin: kàn jiàn
+  - chinese: 一
+    pinyin: yī
+  - chinese: 位
+    pinyin: wèi
+  - chinese: 男人
+    pinyin: nán rén
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 进
+    pinyin: jìn
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 。
+    pinyin: ''
+  english: I saw a man walk into the room.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 听写
+    pinyin: tīng xiě
+  - chinese: 中
+    pinyin: zhōng
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 错误
+    pinyin: cuò wù
+  - chinese: 。
+    pinyin: ''
+  english: I made no mistakes in the dictation.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 开始
+    pinyin: kāi shǐ
+  - chinese: 听写
+    pinyin: tīng xiě
+  - chinese: 。
+    pinyin: ''
+  english: Please begin the dictation.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 新年
+    pinyin: xīn nián
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 了
+    pinyin: le
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 好吃
+    pinyin: hǎo chī
+  - chinese: 的
+    pinyin: de
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 。
+    pinyin: ''
+  english: I ate a lot of delicious food during the New Year.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 考
+    pinyin: kǎo
+  - chinese: 了
+    pinyin: le
+  - chinese: 八十
+    pinyin: bā shí
+  - chinese: 五
+    pinyin: wǔ
+  - chinese: 分
+    pinyin: fēn
+  - chinese: 。
+    pinyin: ''
+  english: I scored 85 points on the test.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 考
+    pinyin: kǎo
+  - chinese: 了
+    pinyin: le
+  - chinese: 八
+    pinyin: bā
+  - chinese: 分
+    pinyin: fēn
+  - chinese: 。
+    pinyin: ''
+  english: I scored 8 points on the test.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 几分
+    pinyin: jǐ fēn
+  - chinese: 对
+    pinyin: duì
+  - chinese: ，
+    pinyin: ''
+  - chinese: 几分
+    pinyin: jǐ fēn
+  - chinese: 不
+    pinyin: bù
+  - chinese: 对
+    pinyin: duì
+  - chinese: 。
+    pinyin: ''
+  english: This question is partly right and partly wrong.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 的
+    pinyin: de
+  - chinese: 风
+    pinyin: fēng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 。
+    pinyin: ''
+  english: The wind is cold today.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 上次
+    pinyin: shàng cì
+  - chinese: 开车
+    pinyin: kāi chē
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 九
+    pinyin: jiǔ
+  - chinese: 零
+    pinyin: líng
+  - chinese: 年
+    pinyin: nián
+  - chinese: 。
+    pinyin: ''
+  english: I last drove a car in nineteen ninety.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 慢
+    pinyin: màn
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 开车
+    pinyin: kāi chē
+  - chinese: 。
+    pinyin: ''
+  english: Please drive slowly.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 得
+    pinyin: de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 慢
+    pinyin: màn
+  - chinese: 。
+    pinyin: ''
+  english: He walks very slowly.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 辆
+    pinyin: liàng
+  - chinese: 车
+    pinyin: chē
+  - chinese: 比
+    pinyin: bǐ
+  - chinese: 那
+    pinyin: nà
+  - chinese: 辆
+    pinyin: liàng
+  - chinese: 车
+    pinyin: chē
+  - chinese: 慢
+    pinyin: màn
+  - chinese: 。
+    pinyin: ''
+  english: This car is slower than that car.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 跑
+    pinyin: pǎo
+  - chinese: 得
+    pinyin: de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 快
+    pinyin: kuài
+  - chinese: 。
+    pinyin: ''
+  english: She runs very fast.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 为什么
+    pinyin: wèi shén me
+  - chinese: 跑
+    pinyin: pǎo
+  - chinese: 回家
+    pinyin: huí jiā
+  - chinese: ？
+    pinyin: ''
+  english: Why did you run home?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 肉
+    pinyin: ròu
+  - chinese: 。
+    pinyin: ''
+  english: I love to eat meat.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 树
+    pinyin: shù
+  - chinese: 下
+    pinyin: xià
+  - chinese: 等
+    pinyin: děng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 。
+    pinyin: ''
+  english: Wait for me under the tree.
+
+- segments:
+  - chinese: 谢谢
+    pinyin: xiè xie
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 开车
+    pinyin: kāi chē
+  - chinese: 送
+    pinyin: sòng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 回家
+    pinyin: huí jiā
+  - chinese: 。
+    pinyin: ''
+  english: Thank you for driving me home.
+
+- segments:
+  - chinese: 记住
+    pinyin: jì zhu
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 日期
+    pinyin: rì qī
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 重要
+    pinyin: zhòng yào
+  - chinese: 。
+    pinyin: ''
+  english: It's important to remember this date.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 他
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 歌
+    pinyin: gē
+  - chinese: 。
+    pinyin: ''
+  english: I like listening to his songs.
+
+- segments:
+  - chinese: 最后
+    pinyin: zuì hòu
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 找到
+    pinyin: zhǎo dào
+  - chinese: 了
+    pinyin: le
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 手机
+    pinyin: shǒu jī
+  - chinese: 。
+    pinyin: ''
+  english: In the end, I found my phone.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 小学
+    pinyin: xiǎo xué
+  - chinese: 交
+    pinyin: jiāo
+  - chinese: 了
+    pinyin: le
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 。
+    pinyin: ''
+  english: I made a lot of friends in elementary school.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 孩子
+    pinyin: hái zi
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 小学
+    pinyin: xiǎo xué
+  - chinese: 。
+    pinyin: ''
+  english: My child loves going to elementary school.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 同学
+    pinyin: tóng xué
+  - chinese: 们
+    pinyin: men
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 玩
+    pinyin: wán
+  - chinese: 球
+    pinyin: qiú
+  - chinese: 。
+    pinyin: ''
+  english: My classmates like to play ball.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 牛奶
+    pinyin: niú nǎi
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you like drinking milk?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 早上
+    pinyin: zǎo shang
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 一
+    pinyin: yī
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 牛奶
+    pinyin: niú nǎi
+  - chinese: 。
+    pinyin: ''
+  english: I drink a glass of milk every morning.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 咖啡
+    pinyin: kā fēi
+  - chinese: 加
+    pinyin: jiā
+  - chinese: 牛奶
+    pinyin: niú nǎi
+  - chinese: 。
+    pinyin: ''
+  english: I like drinking coffee with milk.
+
+- segments:
+  - chinese: 北京
+    pinyin: Běi jīng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 好玩儿
+    pinyin: hǎo wán r
+  - chinese: 的
+    pinyin: de
+  - chinese: 地方
+    pinyin: dì fāng
+  - chinese: 。
+    pinyin: ''
+  english: Beijing has many fun places to visit.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 第
+    pinyin: dì
+  - chinese: 二
+    pinyin: èr
+  - chinese: 次
+    pinyin: cì
+  - chinese: 来
+    pinyin: lái
+  - chinese: 中国
+    pinyin: Zhōng guó
+  - chinese: 。
+    pinyin: ''
+  english: This is my second time coming to China.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 爱
+    pinyin: ài
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 国家
+    pinyin: guó jiā
+  - chinese: 。
+    pinyin: ''
+  english: I love my country.
+
+- segments:
+  - chinese: 中国
+    pinyin: Zhōng guó
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 大
+    pinyin: dà
+  - chinese: 国家
+    pinyin: guó jiā
+  - chinese: 。
+    pinyin: ''
+  english: China is a big country.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 哪
+    pinyin: nǎ
+  - chinese: 个
+    pinyin: gè
+  - chinese: 国家
+    pinyin: guó jiā
+  - chinese: 的
+    pinyin: de
+  - chinese: 国旗
+    pinyin: guó qí
+  - chinese: ？
+    pinyin: ''
+  english: Which country's flag is this?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 过
+    pinyin: guò
+  - chinese: 哪些
+    pinyin: nǎ xiē
+  - chinese: 国家
+    pinyin: guó jiā
+  - chinese: ？
+    pinyin: ''
+  english: Which countries have you been to?
+
+- segments:
+  - chinese: 国家
+    pinyin: guó jiā
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 美丽
+    pinyin: měi lì
+  - chinese: 的
+    pinyin: de
+  - chinese: 地方
+    pinyin: dì fāng
+  - chinese: 。
+    pinyin: ''
+  english: The country has many beautiful places.
+
+- segments:
+  - chinese: 鸡蛋
+    pinyin: jī dàn
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪里
+    pinyin: nǎ lǐ
+  - chinese: ？
+    pinyin: ''
+  english: Where are the eggs?
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 十
+    pinyin: shí
+  - chinese: 块
+    pinyin: kuài
+  - chinese: 钱
+    pinyin: qián
+  - chinese: 。
+    pinyin: ''
+  english: This book is 10 yuan.
+
+- segments:
+  - chinese: 请进
+    pinyin: qǐng jìn
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 。
+    pinyin: ''
+  english: Please enter the room.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 进
+    pinyin: jìn
+  - chinese: 图书馆
+    pinyin: tú shū guǎn
+  - chinese: 看书
+    pinyin: kàn shū
+  - chinese: 。
+    pinyin: ''
+  english: He enjoys going to the library to read books.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 看见
+    pinyin: kàn jiàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: He saw a book.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 看见
+    pinyin: kàn jiàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 一
+    pinyin: yī
+  - chinese: 只
+    pinyin: zhǐ
+  - chinese: 小
+    pinyin: xiǎo
+  - chinese: 猫
+    pinyin: māo
+  - chinese: 。
+    pinyin: ''
+  english: I saw a kitten.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 看见
+    pinyin: kàn jiàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 高山
+    pinyin: gāo shān
+  - chinese: 。
+    pinyin: ''
+  english: She saw a tall mountain.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 看见
+    pinyin: kàn jiàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 漂亮
+    pinyin: piào liang
+  - chinese: 的
+    pinyin: de
+  - chinese: 花儿
+    pinyin: huā r
+  - chinese: 。
+    pinyin: ''
+  english: We saw beautiful flowers.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 看见
+    pinyin: kàn jiàn
+  - chinese: 了
+    pinyin: le
+  - chinese: 彩虹
+    pinyin: cǎi hóng
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Did you see the rainbow?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 试
+    pinyin: shì
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 。
+    pinyin: ''
+  english: I want to try on this piece of clothing.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 试
+    pinyin: shì
+  - chinese: 一下
+    pinyin: yī xià
+  - chinese: 。
+    pinyin: ''
+  english: You can give it a try.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 试
+    pinyin: shì
+  - chinese: 新
+    pinyin: xīn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 。
+    pinyin: ''
+  english: I like trying on new clothes.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 最好
+    pinyin: zuì hǎo
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 完
+    pinyin: wán
+  - chinese: 。
+    pinyin: ''
+  english: You should finish reading this book.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 最好
+    pinyin: zuì hǎo
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 。
+    pinyin: ''
+  english: You should eat something.
+
+- segments:
+  - chinese: 最好
+    pinyin: zuì hǎo
+  - chinese: 问
+    pinyin: wèn
+  - chinese: 问
+    pinyin: wèn
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 。
+    pinyin: ''
+  english: It's best to ask the teacher.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 听到
+    pinyin: tīng dào
+  - chinese: 别人
+    pinyin: bié ren
+  - chinese: 说话
+    pinyin: shuō huà
+  - chinese: 。
+    pinyin: ''
+  english: I hear others talking.
+
+- segments:
+  - chinese: 不客气
+    pinyin: bù kè qi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 是
+    pinyin: shì
+  - chinese: 一家人
+    pinyin: yī jiā rén
+  - chinese: 。
+    pinyin: ''
+  english: You're welcome, we are one family.
+
+- segments:
+  - chinese: 对不起
+    pinyin: duì bu qǐ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 时间
+    pinyin: shí jiān
+  - chinese: 。
+    pinyin: ''
+  english: Sorry, I don't have time.
+
+- segments:
+  - chinese: 教学楼
+    pinyin: jiào xué lóu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 大
+    pinyin: dà
+  - chinese: 。
+    pinyin: ''
+  english: The teaching building is big.
+
+- segments:
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 在
+    pinyin: zài
+  - chinese: 教学楼
+    pinyin: jiào xué lóu
+  - chinese: 教书
+    pinyin: jiāo shū
+  - chinese: 。
+    pinyin: ''
+  english: The teacher teaches in the teaching building.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 教学楼
+    pinyin: jiào xué lóu
+  - chinese: 上课
+    pinyin: shàng kè
+  - chinese: 。
+    pinyin: ''
+  english: We have classes in the teaching building.
+
+- segments:
+  - chinese: 教学楼
+    pinyin: jiào xué lóu
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 教室
+    pinyin: jiào shì
+  - chinese: 。
+    pinyin: ''
+  english: The teaching building has many classrooms.
+
+- segments:
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 们
+    pinyin: men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 教学楼
+    pinyin: jiào xué lóu
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 。
+    pinyin: ''
+  english: Students study in the teaching building.
+
+- segments:
+  - chinese: 那
+    pinyin: nà
+  - chinese: 个
+    pinyin: gè
+  - chinese: 男人
+    pinyin: nán rén
+  - chinese: 在
+    pinyin: zài
+  - chinese: 路上
+    pinyin: lù shang
+  - chinese: 跑
+    pinyin: pǎo
+  - chinese: 。
+    pinyin: ''
+  english: That man is running on the road.
+
+- segments:
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 上边
+    pinyin: shàng bian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: There is a book on the table.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 站
+    pinyin: zhàn
+  - chinese: 在
+    pinyin: zài
+  - chinese: 山
+    pinyin: shān
+  - chinese: 上边
+    pinyin: shàng bian
+  - chinese: 。
+    pinyin: ''
+  english: He is standing on the mountain.
+
+- segments:
+  - chinese: 书架
+    pinyin: shū jià
+  - chinese: 上边
+    pinyin: shàng bian
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: There are many books on the bookshelf.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 生气
+    pinyin: shēng qì
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: He got angry.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 不
+    pinyin: bù
+  - chinese: 会
+    pinyin: huì
+  - chinese: 生气
+    pinyin: shēng qì
+  - chinese: 。
+    pinyin: ''
+  english: She won't get angry.
+
+- segments:
+  - chinese: 不
+    pinyin: bù
+  - chinese: 要
+    pinyin: yào
+  - chinese: 生气
+    pinyin: shēng qì
+  - chinese: 。
+    pinyin: ''
+  english: Don't get angry.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 生气
+    pinyin: shēng qì
+  - chinese: 。
+    pinyin: ''
+  english: I am very angry.
+
+- segments:
+  - chinese: 别
+    pinyin: bié
+  - chinese: 让
+    pinyin: ràng
+  - chinese: 他
+    pinyin: tā
+  - chinese: 生气
+    pinyin: shēng qì
+  - chinese: 。
+    pinyin: ''
+  english: Don't make him angry.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 球
+    pinyin: qiú
+  - chinese: 。
+    pinyin: ''
+  english: I like this ball.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 找不到
+    pinyin: zhǎo bu dào
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 球
+    pinyin: qiú
+  - chinese: 。
+    pinyin: ''
+  english: I can't find my ball.
+
+- segments:
+  - chinese: 马路
+    pinyin: mǎ lù
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 车
+    pinyin: chē
+  - chinese: 。
+    pinyin: ''
+  english: There are many cars on the road.
+
+- segments:
+  - chinese: 忘记
+    pinyin: wàng jì
+  - chinese: 了
+    pinyin: le
+  - chinese: 也
+    pinyin: yě
+  - chinese: 没关系
+    pinyin: méi guān xi
+  - chinese: 。
+    pinyin: ''
+  english: It's okay if you forgot.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 会
+    pinyin: huì
+  - chinese: 回
+    pinyin: huí
+  - chinese: 电话
+    pinyin: diàn huà
+  - chinese: 。
+    pinyin: ''
+  english: He will return the call.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 进
+    pinyin: jìn
+  - chinese: 了
+    pinyin: le
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 。
+    pinyin: ''
+  english: He entered the room.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 听写
+    pinyin: tīng xiě
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小时
+    pinyin: xiǎo shí
+  - chinese: 。
+    pinyin: ''
+  english: She does dictation for one hour every day.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 听写
+    pinyin: tīng xiě
+  - chinese: 考试
+    pinyin: kǎo shì
+  - chinese: 。
+    pinyin: ''
+  english: He is preparing for the dictation test.
+
+- segments:
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 让
+    pinyin: ràng
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 听写
+    pinyin: tīng xiě
+  - chinese: 。
+    pinyin: ''
+  english: The teacher asked us to do dictation.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 唱
+    pinyin: chàng
+  - chinese: 起来
+    pinyin: qi lai
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Let's start singing.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 跑
+    pinyin: pǎo
+  - chinese: 起来
+    pinyin: qi lai
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: He started running.
+
+- segments:
+  - chinese: 车
+    pinyin: chē
+  - chinese: 开
+    pinyin: kāi
+  - chinese: 起来
+    pinyin: qi lai
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: The car started moving.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 笑
+    pinyin: xiào
+  - chinese: 起来
+    pinyin: qi lai
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: She started laughing.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 小孩
+    pinyin: xiǎo hái
+  - chinese: 病
+    pinyin: bìng
+  - chinese: 得很
+    pinyin: de hěn
+  - chinese: 重
+    pinyin: zhòng
+  - chinese: 。
+    pinyin: ''
+  english: This child is very sick.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 病
+    pinyin: bìng
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: My mom is sick.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 病
+    pinyin: bìng
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: He has recovered from his illness.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: I am looking at the book.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 。
+    pinyin: ''
+  english: He is looking at me.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 窗
+    pinyin: chuāng
+  - chinese: 外
+    pinyin: wài
+  - chinese: 。
+    pinyin: ''
+  english: She is looking out of the window.
+
+- segments:
+  - chinese: 孩子
+    pinyin: hái zi
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 电视
+    pinyin: diàn shì
+  - chinese: 。
+    pinyin: ''
+  english: The child is watching TV.
+
+- segments:
+  - chinese: 爸爸
+    pinyin: bà ba
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 报纸
+    pinyin: bào zhǐ
+  - chinese: 。
+    pinyin: ''
+  english: Dad is reading the newspaper.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 手机
+    pinyin: shǒu jī
+  - chinese: 。
+    pinyin: ''
+  english: I am looking at the phone.
+
+- segments:
+  - chinese: 他们
+    pinyin: tā men
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 地图
+    pinyin: dì tú
+  - chinese: 。
+    pinyin: ''
+  english: They are looking at the map.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 镜子
+    pinyin: jìng zi
+  - chinese: 。
+    pinyin: ''
+  english: She is looking in the mirror.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 画
+    pinyin: huà
+  - chinese: 。
+    pinyin: ''
+  english: I am looking at the painting.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 星星
+    pinyin: xīng xing
+  - chinese: 。
+    pinyin: ''
+  english: He is looking at the stars.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 饿
+    pinyin: è
+  - chinese: 。
+    pinyin: ''
+  english: I am not hungry.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 不
+    pinyin: bù
+  - chinese: 高兴
+    pinyin: gāo xìng
+  - chinese: 。
+    pinyin: ''
+  english: He is not happy.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 不
+    pinyin: bù
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: This is not my book.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 不
+    pinyin: bù
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: She does not like apples.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 不
+    pinyin: bù
+  - chinese: 会
+    pinyin: huì
+  - chinese: 游泳
+    pinyin: yóu yǒng
+  - chinese: 。
+    pinyin: ''
+  english: He cannot swim.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 明白
+    pinyin: míng bai
+  - chinese: 。
+    pinyin: ''
+  english: I do not understand.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 个
+    pinyin: gè
+  - chinese: 孩子
+    pinyin: hái zi
+  - chinese: 不
+    pinyin: bù
+  - chinese: 哭
+    pinyin: kū
+  - chinese: 。
+    pinyin: ''
+  english: This child is not crying.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 不
+    pinyin: bù
+  - chinese: 说谎
+    pinyin: shuō huǎng
+  - chinese: 。
+    pinyin: ''
+  english: We do not telllies.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 还
+    pinyin: hái
+  - chinese: 不
+    pinyin: bù
+  - chinese: 会
+    pinyin: huì
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 汉语
+    pinyin: Hàn yǔ
+  - chinese: 。
+    pinyin: ''
+  english: I still can't speak Chinese.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 还
+    pinyin: hái
+  - chinese: 在
+    pinyin: zài
+  - chinese: 这里
+    pinyin: zhè lǐ
+  - chinese: 。
+    pinyin: ''
+  english: He is still here.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 还
+    pinyin: hái
+  - chinese: 下雨
+    pinyin: xià yǔ
+  - chinese: 。
+    pinyin: ''
+  english: It's still raining today.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 还
+    pinyin: hái
+  - chinese: 没
+    pinyin: méi
+  - chinese: 回家
+    pinyin: huí jiā
+  - chinese: 。
+    pinyin: ''
+  english: He hasn't gone home yet.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 出
+    pinyin: chū
+  - chinese: 了
+    pinyin: le
+  - chinese: 问题
+    pinyin: wèn tí
+  - chinese: 。
+    pinyin: ''
+  english: We had a problem.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 英语
+    pinyin: Yīng yǔ
+  - chinese: 。
+    pinyin: ''
+  english: I can speak English.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 。
+    pinyin: ''
+  english: I go to school.
+
+- segments:
+  - chinese: 大家
+    pinyin: dà jiā
+  - chinese: 不客气
+    pinyin: bù kè qi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 饭
+    pinyin: fàn
+  - chinese: 吧
+    pinyin: ba
+  - chinese: ！
+    pinyin: ''
+  english: Everyone, don't be polite, let's eat!
+
+- segments:
+  - chinese: 不客气
+    pinyin: bù kè qi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 进来
+    pinyin: jìn lái
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 。
+    pinyin: ''
+  english: Don't be polite, please come in and sit.
+
+- segments:
+  - chinese: 不客气
+    pinyin: bù kè qi
+  - chinese: ，
+    pinyin: ''
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 。
+    pinyin: ''
+  english: Don't be polite, this is my friend.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 名字
+    pinyin: míng zi
+  - chinese: 。
+    pinyin: ''
+  english: He knows my name.
+
+- segments:
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 。
+    pinyin: ''
+  english: The teacher knows us.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 谁
+    pinyin: shéi
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you know who he is?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不
+    pinyin: bù
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 这个
+    pinyin: zhè ge
+  - chinese: 字
+    pinyin: zì
+  - chinese: 。
+    pinyin: ''
+  english: I don't know this character.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 课
+    pinyin: kè
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you know there is class tomorrow?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 他
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 哪儿
+    pinyin: nǎ r
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you know where he is?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 没
+    pinyin: méi
+  - chinese: 去
+    pinyin: qù
+  - chinese: 。
+    pinyin: ''
+  english: I didn't go yesterday.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 没
+    pinyin: méi
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 饭
+    pinyin: fàn
+  - chinese: 。
+    pinyin: ''
+  english: He didn't eat today.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 还
+    pinyin: hái
+  - chinese: 没
+    pinyin: méi
+  - chinese: 准备
+    pinyin: zhǔn bèi
+  - chinese: 。
+    pinyin: ''
+  english: I haven't prepared yet.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 还
+    pinyin: hái
+  - chinese: 没
+    pinyin: méi
+  - chinese: 来
+    pinyin: lái
+  - chinese: 。
+    pinyin: ''
+  english: He hasn't come yet.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 爸爸
+    pinyin: bà ba
+  - chinese: 和
+    pinyin: hé
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 。
+    pinyin: ''
+  english: I have a dad and a mom.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 茶
+    pinyin: chá
+  - chinese: 和
+    pinyin: hé
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 。
+    pinyin: ''
+  english: I like to drink tea and water.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 和
+    pinyin: hé
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 说话
+    pinyin: shuō huà
+  - chinese: 。
+    pinyin: ''
+  english: I like to talk with friends.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 常常
+    pinyin: cháng cháng
+  - chinese: 和
+    pinyin: hé
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 东西
+    pinyin: dōng xi
+  - chinese: 。
+    pinyin: ''
+  english: I often go shopping with my mom.
+
+- segments:
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 和
+    pinyin: hé
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 重要
+    pinyin: zhòng yào
+  - chinese: 。
+    pinyin: ''
+  english: Study and work are both important.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 到
+    pinyin: dào
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I have arrived at school.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 到
+    pinyin: dào
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: He arrived home.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 几
+    pinyin: jǐ
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 到
+    pinyin: dào
+  - chinese: ？
+    pinyin: ''
+  english: What time will you arrive?
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 学
+    pinyin: xué
+  - chinese: 到
+    pinyin: dào
+  - chinese: 第
+    pinyin: dì
+  - chinese: 三
+    pinyin: sān
+  - chinese: 课
+    pinyin: kè
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: We've studied up to Lesson 3.
+
+- segments:
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 开
+    pinyin: kāi
+  - chinese: 到
+    pinyin: dào
+  - chinese: 十
+    pinyin: shí
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 。
+    pinyin: ''
+  english: The shop is open until 10 o'clock.
+
+- segments:
+  - chinese: 等到
+    pinyin: děng dào
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 再
+    pinyin: zài
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 。
+    pinyin: ''
+  english: Wait until tomorrow to talk about it.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 得
+    pinyin: de
+  - chinese: 对
+    pinyin: duì
+  - chinese: 。
+    pinyin: ''
+  english: What you said is right.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 是
+    pinyin: shì
+  - chinese: 对
+    pinyin: duì
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: This is correct.
+
+- segments:
+  - chinese: 对
+    pinyin: duì
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不
+    pinyin: bù
+  - chinese: 是
+    pinyin: shì
+  - chinese: 错
+    pinyin: cuò
+  - chinese: 。
+    pinyin: ''
+  english: Right, not wrong.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 对
+    pinyin: duì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: He is very nice to me.
+
+- segments:
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 课
+    pinyin: kè
+  - chinese: ，
+    pinyin: ''
+  - chinese: 对
+    pinyin: duì
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: We have class tomorrow, right?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 写
+    pinyin: xiě
+  - chinese: 得
+    pinyin: de
+  - chinese: 对
+    pinyin: duì
+  - chinese: 。
+    pinyin: ''
+  english: You wrote it correctly.
+
+- segments:
+  - chinese: 对
+    pinyin: duì
+  - chinese: 呀
+    pinyin: ya
+  - chinese: ！
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 也
+    pinyin: yě
+  - chinese: 这么
+    pinyin: zhè me
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 。
+    pinyin: ''
+  english: Right! I think so too.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 对
+    pinyin: duì
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 笑
+    pinyin: xiào
+  - chinese: 。
+    pinyin: ''
+  english: I smile at you.
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 对
+    pinyin: duì
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: Mom is very nice to me.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 也
+    pinyin: yě
+  - chinese: 去
+    pinyin: qù
+  - chinese: 。
+    pinyin: ''
+  english: I am going too.
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 也
+    pinyin: yě
+  - chinese: 在
+    pinyin: zài
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 。
+    pinyin: ''
+  english: Mom is at home too.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 也
+    pinyin: yě
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: He also likes apples.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 也
+    pinyin: yě
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 高兴
+    pinyin: gāo xìng
+  - chinese: 。
+    pinyin: ''
+  english: I am also very happy.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 也
+    pinyin: yě
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 哥哥
+    pinyin: gē ge
+  - chinese: 。
+    pinyin: ''
+  english: I also have an older brother.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 也
+    pinyin: yě
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: She also has a book.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 也
+    pinyin: yě
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 汉语
+    pinyin: Hàn yǔ
+  - chinese: 。
+    pinyin: ''
+  english: I also study Chinese.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 也
+    pinyin: yě
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 手机
+    pinyin: shǒu jī
+  - chinese: 。
+    pinyin: ''
+  english: He also has a phone.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 也
+    pinyin: yě
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 书包
+    pinyin: shū bāo
+  - chinese: 。
+    pinyin: ''
+  english: I also have a backpack.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 忙
+    pinyin: máng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 也
+    pinyin: yě
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 忙
+    pinyin: máng
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: I'm very busy. Are you busy too?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 跑
+    pinyin: pǎo
+  - chinese: 得
+    pinyin: de
+  - chinese: 快
+    pinyin: kuài
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 也
+    pinyin: yě
+  - chinese: 跑
+    pinyin: pǎo
+  - chinese: 得
+    pinyin: de
+  - chinese: 快
+    pinyin: kuài
+  - chinese: 。
+    pinyin: ''
+  english: He runs fast, and I run fast too.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 还
+    pinyin: hái
+  - chinese: 在
+    pinyin: zài
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 。
+    pinyin: ''
+  english: I'm still at school.
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 还
+    pinyin: hái
+  - chinese: 在
+    pinyin: zài
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Is mom still at home?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 中文
+    pinyin: Zhōng wén
+  - chinese: ，
+    pinyin: ''
+  - chinese: 还
+    pinyin: hái
+  - chinese: 会
+    pinyin: huì
+  - chinese: 说
+    pinyin: shuō
+  - chinese: 英语
+    pinyin: Yīng yǔ
+  - chinese: 。
+    pinyin: ''
+  english: I can speak Chinese, and also English.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 还
+    pinyin: hái
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 香蕉
+    pinyin: xiāng jiāo
+  - chinese: 。
+    pinyin: ''
+  english: He likes apples, and also bananas.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 还
+    pinyin: hái
+  - chinese: 在
+    pinyin: zài
+  - chinese: 睡觉
+    pinyin: shuì jiào
+  - chinese: 。
+    pinyin: ''
+  english: He's still sleeping.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 会
+    pinyin: huì
+  - chinese: 唱歌
+    pinyin: chàng gē
+  - chinese: ，
+    pinyin: ''
+  - chinese: 还
+    pinyin: hái
+  - chinese: 会
+    pinyin: huì
+  - chinese: 跳舞
+    pinyin: tiào wǔ
+  - chinese: 。
+    pinyin: ''
+  english: I can sing, and also dance.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 红色
+    pinyin: hóng sè
+  - chinese: ，
+    pinyin: ''
+  - chinese: 还
+    pinyin: hái
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 蓝色
+    pinyin: lán sè
+  - chinese: 。
+    pinyin: ''
+  english: She likes red, and also blue.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 还
+    pinyin: hái
+  - chinese: 小
+    pinyin: xiǎo
+  - chinese: ，
+    pinyin: ''
+  - chinese: 却
+    pinyin: què
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 聪明
+    pinyin: cōng ming
+  - chinese: 。
+    pinyin: ''
+  english: He is still young, yet very smart.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 还
+    pinyin: hái
+  - chinese: 没
+    pinyin: méi
+  - chinese: 写
+    pinyin: xiě
+  - chinese: 作业
+    pinyin: zuò yè
+  - chinese: 。
+    pinyin: ''
+  english: I haven't even done my homework yet.
+
+- segments:
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 热
+    pinyin: rè
+  - chinese: ！
+    pinyin: ''
+  english: The weather is really hot!
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 好看
+    pinyin: hǎo kàn
+  - chinese: 。
+    pinyin: ''
+  english: This book is really good.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 聪明
+    pinyin: cōng ming
+  - chinese: ！
+    pinyin: ''
+  english: You are really smart!
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 不
+    pinyin: bù
+  - chinese: 知道
+    pinyin: zhī dào
+  - chinese: 。
+    pinyin: ''
+  english: I really don't know.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 高
+    pinyin: gāo
+  - chinese: ！
+    pinyin: ''
+  english: He is really tall!
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 。
+    pinyin: ''
+  english: It's really cold today.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 道
+    pinyin: dào
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 好吃
+    pinyin: hǎo chī
+  - chinese: 。
+    pinyin: ''
+  english: This dish is really delicious.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 来
+    pinyin: lái
+  - chinese: 了
+    pinyin: le
+  - chinese: ！
+    pinyin: ''
+  english: You really came!
+
+- segments:
+  - chinese: 真
+    pinyin: zhēn
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 不
+    pinyin: bù
+  - chinese: 多
+    pinyin: duō
+  - chinese: 。
+    pinyin: ''
+  english: True friends are few.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 多
+    pinyin: duō
+  - chinese: 事
+    pinyin: shì
+  - chinese: 。
+    pinyin: ''
+  english: There are many things to do today.
+
+- segments:
+  - chinese: 这个
+    pinyin: zhè ge
+  - chinese: 事
+    pinyin: shì
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 重要
+    pinyin: zhòng yào
+  - chinese: 。
+    pinyin: ''
+  english: This matter is very important.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 现在
+    pinyin: xiàn zài
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Are you eating now?
+
+- segments:
+  - chinese: 现在
+    pinyin: xiàn zài
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can we go now?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 茶
+    pinyin: chá
+  - chinese: ，
+    pinyin: ''
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 呢
+    pinyin: ne
+  - chinese: ？
+    pinyin: ''
+  english: I like drinking tea. What about you?
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: 呢
+    pinyin: ne
+  - chinese: ？
+    pinyin: ''
+  english: What are you doing?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 在
+    pinyin: zài
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 呢
+    pinyin: ne
+  - chinese: 。
+    pinyin: ''
+  english: He is reading (right now).
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 在
+    pinyin: zài
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 饭
+    pinyin: fàn
+  - chinese: 呢
+    pinyin: ne
+  - chinese: 。
+    pinyin: ''
+  english: Mom is cooking (at the moment).
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 得
+    pinyin: de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 快
+    pinyin: kuài
+  - chinese: 。
+    pinyin: ''
+  english: He walks very fast.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Let's walk together.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 现在
+    pinyin: xiàn zài
+  - chinese: 要
+    pinyin: yào
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: I have to leave now.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 什么时候
+    pinyin: shén me shí hou
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: ？
+    pinyin: ''
+  english: When are you leaving?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: He left.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 每天
+    pinyin: měi tiān
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 十
+    pinyin: shí
+  - chinese: 分钟
+    pinyin: fēn zhōng
+  - chinese: 。
+    pinyin: ''
+  english: He walks ten minutes every day.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 回
+    pinyin: huí
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 。
+    pinyin: ''
+  english: Let's walk home together.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 出
+    pinyin: chū
+  - chinese: 房间
+    pinyin: fáng jiān
+  - chinese: 。
+    pinyin: ''
+  english: He walked out of the room.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 先
+    pinyin: xiān
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 。
+    pinyin: ''
+  english: You can go first.
+
+- segments:
+  - chinese: 走
+    pinyin: zǒu
+  - chinese: 吧
+    pinyin: ba
+  - chinese: ，
+    pinyin: ''
+  - chinese: 不要
+    pinyin: bù yào
+  - chinese: 迟到
+    pinyin: chí dào
+  - chinese: 。
+    pinyin: ''
+  english: Let's go, don't be late.
+
+- segments:
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 太
+    pinyin: tài
+  - chinese: 热
+    pinyin: rè
+  - chinese: 了
+    pinyin: le
+  - chinese: ！
+    pinyin: ''
+  english: The weather is too hot!
+
+- segments:
+  - chinese: 太
+    pinyin: tài
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 了
+    pinyin: le
+  - chinese: ！
+    pinyin: ''
+  english: Great! / Excellent!
+
+- segments:
+  - chinese: 太
+    pinyin: tài
+  - chinese: 谢谢
+    pinyin: xiè xie
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 了
+    pinyin: le
+  - chinese: ！
+    pinyin: ''
+  english: Thank you so much!
+
+- segments:
+  - chinese: 太
+    pinyin: tài
+  - chinese: 棒
+    pinyin: bàng
+  - chinese: 了
+    pinyin: le
+  - chinese: ！
+    pinyin: ''
+  english: Awesome!
+
+- segments:
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 一
+    pinyin: yī
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: There is a book on the table.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 。
+    pinyin: ''
+  english: I go to school.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 车
+    pinyin: chē
+  - chinese: 了
+    pinyin: le
+  - chinese: 。
+    pinyin: ''
+  english: He got on the bus.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 楼
+    pinyin: lóu
+  - chinese: 吧
+    pinyin: ba
+  - chinese: 。
+    pinyin: ''
+  english: Let's go upstairs.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 钱
+    pinyin: qián
+  - chinese: 。
+    pinyin: ''
+  english: I don't have money.
+
+- segments:
+  - chinese: 桌子
+    pinyin: zhuō zi
+  - chinese: 上
+    pinyin: shàng
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: There are no books on the table.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 。
+    pinyin: ''
+  english: He doesn't have friends.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 昨天
+    pinyin: zuó tiān
+  - chinese: 没有
+    pinyin: méi yǒu
+  - chinese: 去
+    pinyin: qù
+  - chinese: 学校
+    pinyin: xué xiào
+  - chinese: 。
+    pinyin: ''
+  english: I didn't go to school yesterday.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: He is sitting and reading.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 拿
+    pinyin: ná
+  - chinese: 着
+    pinyin: zhe
+  - chinese: 手机
+    pinyin: shǒu jī
+  - chinese: 。
+    pinyin: ''
+  english: I'm holding the phone.
+
+- segments:
+  - chinese: 别
+    pinyin: bié
+  - chinese: 坐
+    pinyin: zuò
+  - chinese: 这里
+    pinyin: zhè lǐ
+  - chinese: 。
+    pinyin: ''
+  english: Don't sit here.
+
+- segments:
+  - chinese: 别
+    pinyin: bié
+  - chinese: 迟到
+    pinyin: chí dào
+  - chinese: 。
+    pinyin: ''
+  english: Don't be late.
+
+- segments:
+  - chinese: 别
+    pinyin: bié
+  - chinese: 生气
+    pinyin: shēng qì
+  - chinese: 。
+    pinyin: ''
+  english: Don't be angry.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 去
+    pinyin: qù
+  - chinese: 商店
+    pinyin: shāng diàn
+  - chinese: 。
+    pinyin: ''
+  english: I go to the store with my friend.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 。
+    pinyin: ''
+  english: He studies together with me.
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 。
+    pinyin: ''
+  english: Mom is at home with me.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 都
+    pinyin: dōu
+  - chinese: 是
+    pinyin: shì
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 。
+    pinyin: ''
+  english: You and I are both students.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 一样
+    pinyin: yī yàng
+  - chinese: 高
+    pinyin: gāo
+  - chinese: 。
+    pinyin: ''
+  english: He is as tall as me.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 衣服
+    pinyin: yī fu
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 那
+    pinyin: nà
+  - chinese: 件
+    pinyin: jiàn
+  - chinese: 一样
+    pinyin: yī yàng
+  - chinese: 。
+    pinyin: ''
+  english: This piece of clothing is the same as that one.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 来
+    pinyin: lái
+  - chinese: 。
+    pinyin: ''
+  english: Follow me.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 去
+    pinyin: qù
+  - chinese: 买
+    pinyin: mǎi
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 。
+    pinyin: ''
+  english: She goes shopping with her mom.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 跟
+    pinyin: gēn
+  - chinese: 他
+    pinyin: tā
+  - chinese: 是
+    pinyin: shì
+  - chinese: 同学
+    pinyin: tóng xué
+  - chinese: 。
+    pinyin: ''
+  english: He and I are classmates.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 告诉
+    pinyin: gào su
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 名字
+    pinyin: míng zi
+  - chinese: 。
+    pinyin: ''
+  english: Please tell me your name.
+
+- segments:
+  - chinese: 妈妈
+    pinyin: mā ma
+  - chinese: 告诉
+    pinyin: gào su
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 不要
+    pinyin: bù yào
+  - chinese: 迟到
+    pinyin: chí dào
+  - chinese: 。
+    pinyin: ''
+  english: Mom told me not to be late.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 告诉
+    pinyin: gào su
+  - chinese: 他
+    pinyin: tā
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 忙
+    pinyin: máng
+  - chinese: 。
+    pinyin: ''
+  english: I told him I'm very busy.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 告诉
+    pinyin: gào su
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 他
+    pinyin: tā
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 中国
+    pinyin: Zhōng guó
+  - chinese: 菜
+    pinyin: cài
+  - chinese: 。
+    pinyin: ''
+  english: He told me he likes Chinese food.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 告诉
+    pinyin: gào su
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 去
+    pinyin: qù
+  - chinese: 火车站
+    pinyin: huǒ chē zhàn
+  - chinese: 。
+    pinyin: ''
+  english: Please tell me how to get to the train station.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 告诉
+    pinyin: gào su
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 。
+    pinyin: ''
+  english: She told me it's very cold today.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 没
+    pinyin: méi
+  - chinese: 告诉
+    pinyin: gào su
+  - chinese: 他
+    pinyin: tā
+  - chinese: 。
+    pinyin: ''
+  english: I didn't tell him.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 告诉
+    pinyin: gào su
+  - chinese: 过
+    pinyin: guo
+  - chinese: 她
+    pinyin: tā
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Have you told her?
+
+- segments:
+  - chinese: 谁
+    pinyin: shéi
+  - chinese: 告诉
+    pinyin: gào su
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 这个
+    pinyin: zhè ge
+  - chinese: ？
+    pinyin: ''
+  english: Who told you this?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 再
+    pinyin: zài
+  - chinese: 去
+    pinyin: qù
+  - chinese: 一
+    pinyin: yī
+  - chinese: 次
+    pinyin: cì
+  - chinese: 。
+    pinyin: ''
+  english: He wants to go again.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 想
+    pinyin: xiǎng
+  - chinese: 再
+    pinyin: zài
+  - chinese: 要
+    pinyin: yào
+  - chinese: 一
+    pinyin: yī
+  - chinese: 杯
+    pinyin: bēi
+  - chinese: 水
+    pinyin: shuǐ
+  - chinese: 。
+    pinyin: ''
+  english: I want another glass of water.
+
+- segments:
+  - chinese: 再
+    pinyin: zài
+  - chinese: 来
+    pinyin: lái
+  - chinese: 一
+    pinyin: yī
+  - chinese: 个
+    pinyin: gè
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: Give me one more apple.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 可以
+    pinyin: kě yǐ
+  - chinese: 再
+    pinyin: zài
+  - chinese: 等
+    pinyin: děng
+  - chinese: 一下
+    pinyin: yī xià
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Can you wait a little longer?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 吃饭
+    pinyin: chī fàn
+  - chinese: ，
+    pinyin: ''
+  - chinese: 再
+    pinyin: zài
+  - chinese: 去
+    pinyin: qù
+  - chinese: 上课
+    pinyin: shàng kè
+  - chinese: 。
+    pinyin: ''
+  english: I'll eat, then go to class.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 中文
+    pinyin: Zhōng wén
+  - chinese: 歌
+    pinyin: gē
+  - chinese: 。
+    pinyin: ''
+  english: He likes listening to Chinese songs.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: I'll do as the teacher says.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 中文
+    pinyin: Zhōng wén
+  - chinese: 歌
+    pinyin: gē
+  - chinese: 。
+    pinyin: ''
+  english: We listen to Chinese songs together.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 听
+    pinyin: tīng
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: I'll do as you say.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 用
+    pinyin: yòng
+  - chinese: 手机
+    pinyin: shǒu jī
+  - chinese: 打电话
+    pinyin: dǎ diàn huà
+  - chinese: 。
+    pinyin: ''
+  english: I use my phone to make calls.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 用
+    pinyin: yòng
+  - chinese: 电脑
+    pinyin: diàn nǎo
+  - chinese: 工作
+    pinyin: gōng zuò
+  - chinese: 。
+    pinyin: ''
+  english: He works with a computer.
+
+- segments:
+  - chinese: 我们
+    pinyin: wǒ men
+  - chinese: 用
+    pinyin: yòng
+  - chinese: 中文
+    pinyin: Zhōng wén
+  - chinese: 说话
+    pinyin: shuō huà
+  - chinese: 。
+    pinyin: ''
+  english: We speak in Chinese.
+
+- segments:
+  - chinese: 上课
+    pinyin: shàng kè
+  - chinese: 要
+    pinyin: yào
+  - chinese: 用
+    pinyin: yòng
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: You need to use the book in class.
+
+- segments:
+  - chinese: 这个
+    pinyin: zhè ge
+  - chinese: 字
+    pinyin: zì
+  - chinese: 怎么
+    pinyin: zěn me
+  - chinese: 用
+    pinyin: yòng
+  - chinese: ？
+    pinyin: ''
+  english: How do you use this character?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 觉得
+    pinyin: jué de
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好
+    pinyin: hǎo
+  - chinese: 。
+    pinyin: ''
+  english: I think this book is very good.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 觉得
+    pinyin: jué de
+  - chinese: 中文
+    pinyin: Zhōng wén
+  - chinese: 难
+    pinyin: nán
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Do you think Chinese is hard?
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 觉得
+    pinyin: jué de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 累
+    pinyin: lèi
+  - chinese: 。
+    pinyin: ''
+  english: I feel very tired.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 觉得
+    pinyin: jué de
+  - chinese: 不
+    pinyin: bù
+  - chinese: 舒服
+    pinyin: shū fu
+  - chinese: 。
+    pinyin: ''
+  english: She feels unwell.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 觉得
+    pinyin: jué de
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 高兴
+    pinyin: gāo xìng
+  - chinese: 。
+    pinyin: ''
+  english: Today I feel very happy.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 觉得
+    pinyin: jué de
+  - chinese: 这个
+    pinyin: zhè ge
+  - chinese: 饭馆
+    pinyin: fàn guǎn
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 好吃
+    pinyin: hǎo chī
+  - chinese: 。
+    pinyin: ''
+  english: I think this restaurant is very good.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 觉得
+    pinyin: jué de
+  - chinese: 天气
+    pinyin: tiān qì
+  - chinese: 太
+    pinyin: tài
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 。
+    pinyin: ''
+  english: He thinks the weather is too cold.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 觉得
+    pinyin: jué de
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 不
+    pinyin: bù
+  - chinese: 难
+    pinyin: nán
+  - chinese: 。
+    pinyin: ''
+  english: I think this book is not hard.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 觉得
+    pinyin: jué de
+  - chinese: 有点儿
+    pinyin: yǒu diǎn r
+  - chinese: 饿
+    pinyin: è
+  - chinese: 。
+    pinyin: ''
+  english: I feel a little hungry.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 从
+    pinyin: cóng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 朋友
+    pinyin: péng you
+  - chinese: 那里
+    pinyin: nà li
+  - chinese: 来
+    pinyin: lái
+  - chinese: 的
+    pinyin: de
+  - chinese: 。
+    pinyin: ''
+  english: This book came from my friend.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 从
+    pinyin: cóng
+  - chinese: 早上
+    pinyin: zǎo shang
+  - chinese: 八
+    pinyin: bā
+  - chinese: 点
+    pinyin: diǎn
+  - chinese: 开始
+    pinyin: kāi shǐ
+  - chinese: 学习
+    pinyin: xué xí
+  - chinese: 。
+    pinyin: ''
+  english: I've been studying since 8 a.m.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 从
+    pinyin: cóng
+  - chinese: 哪儿
+    pinyin: nǎ r
+  - chinese: 来
+    pinyin: lái
+  - chinese: ？
+    pinyin: ''
+  english: Where do you come from?
+
+- segments:
+  - chinese: 从
+    pinyin: cóng
+  - chinese: 明天
+    pinyin: míng tiān
+  - chinese: 开始
+    pinyin: kāi shǐ
+  - chinese: ，
+    pinyin: ''
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 要
+    pinyin: yào
+  - chinese: 早
+    pinyin: zǎo
+  - chinese: 睡
+    pinyin: shuì
+  - chinese: 。
+    pinyin: ''
+  english: Starting from tomorrow, I'll go to bed early.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 家
+    pinyin: jiā
+  - chinese: 。
+    pinyin: ''
+  english: Her husband is at home.
+
+- segments:
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 位
+    pinyin: wèi
+  - chinese: 女士
+    pinyin: nǚ shì
+  - chinese: 和
+    pinyin: hé
+  - chinese: 她
+    pinyin: tā
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 旅行
+    pinyin: lǚ xíng
+  - chinese: 。
+    pinyin: ''
+  english: This lady is traveling with her husband.
+
+- segments:
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 您
+    pinyin: nín
+  - chinese: 要
+    pinyin: yào
+  - chinese: 喝
+    pinyin: hē
+  - chinese: 茶
+    pinyin: chá
+  - chinese: 吗
+    pinyin: ma
+  - chinese: ？
+    pinyin: ''
+  english: Sir, would you like some tea?
+
+- segments:
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: ，
+    pinyin: ''
+  - chinese: 这里
+    pinyin: zhè lǐ
+  - chinese: 有
+    pinyin: yǒu
+  - chinese: 您
+    pinyin: nín
+  - chinese: 的
+    pinyin: de
+  - chinese: 票
+    pinyin: piào
+  - chinese: 。
+    pinyin: ''
+  english: Sir, here is your ticket.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 和
+    pinyin: hé
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 超市
+    pinyin: chāo shì
+  - chinese: 。
+    pinyin: ''
+  english: She is going to the supermarket with her husband.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: 帮忙
+    pinyin: bāng máng
+  - chinese: 做
+    pinyin: zuò
+  - chinese: 饭
+    pinyin: fàn
+  - chinese: 。
+    pinyin: ''
+  english: She asked her husband to help cook.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 的
+    pinyin: de
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: 在
+    pinyin: zài
+  - chinese: 外面
+    pinyin: wài miàn
+  - chinese: 等
+    pinyin: děng
+  - chinese: 她
+    pinyin: tā
+  - chinese: 。
+    pinyin: ''
+  english: Her husband is waiting for her outside.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 和
+    pinyin: hé
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: 一起
+    pinyin: yī qǐ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 散步
+    pinyin: sàn bù
+  - chinese: 。
+    pinyin: ''
+  english: She is going for a walk with her husband.
+
+- segments:
+  - chinese: 她
+    pinyin: tā
+  - chinese: 先生
+    pinyin: xiān sheng
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 看
+    pinyin: kàn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: Her husband likes reading very much.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 在
+    pinyin: zài
+  - chinese: 找
+    pinyin: zhǎo
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 的
+    pinyin: de
+  - chinese: 手机
+    pinyin: shǒu jī
+  - chinese: 。
+    pinyin: ''
+  english: I'm looking for my phone.
+
+- segments:
+  - chinese: 请
+    pinyin: qǐng
+  - chinese: 帮
+    pinyin: bāng
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 找
+    pinyin: zhǎo
+  - chinese: 这
+    pinyin: zhè
+  - chinese: 本
+    pinyin: běn
+  - chinese: 书
+    pinyin: shū
+  - chinese: 。
+    pinyin: ''
+  english: Please help me find this book.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 去
+    pinyin: qù
+  - chinese: 找
+    pinyin: zhǎo
+  - chinese: 老师
+    pinyin: lǎo shī
+  - chinese: 。
+    pinyin: ''
+  english: I'm going to see the teacher.
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 找
+    pinyin: zhǎo
+  - chinese: 医生
+    pinyin: yī shēng
+  - chinese: 看病
+    pinyin: kàn bìng
+  - chinese: 。
+    pinyin: ''
+  english: He went to see the doctor.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 找
+    pinyin: zhǎo
+  - chinese: 谁
+    pinyin: shéi
+  - chinese: ？
+    pinyin: ''
+  english: Who are you looking for?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 跑
+    pinyin: pǎo
+  - chinese: 得
+    pinyin: de
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 快
+    pinyin: kuài
+  - chinese: 。
+    pinyin: ''
+  english: He runs the fastest.
+
+- segments:
+  - chinese: 今天
+    pinyin: jīn tiān
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 冷
+    pinyin: lěng
+  - chinese: 。
+    pinyin: ''
+  english: Today is the coldest.
+
+- segments:
+  - chinese: 我
+    pinyin: wǒ
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 吃
+    pinyin: chī
+  - chinese: 苹果
+    pinyin: píng guǒ
+  - chinese: 。
+    pinyin: ''
+  english: I like to eat apples the most.
+
+- segments:
+  - chinese: 你
+    pinyin: nǐ
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 喜欢
+    pinyin: xǐ huan
+  - chinese: 什么
+    pinyin: shén me
+  - chinese: ？
+    pinyin: ''
+  english: What do you like the most?
+
+- segments:
+  - chinese: 他
+    pinyin: tā
+  - chinese: 最
+    pinyin: zuì
+  - chinese: 聪明
+    pinyin: cōng ming
+  - chinese: 。
+    pinyin: ''
+  english: He is the smartest.
+
+- segments:
+  - chinese: 学生
+    pinyin: xué sheng
+  - chinese: 们
+    pinyin: men
+  - chinese: 在
+    pinyin: zài
+  - chinese: 上课
+    pinyin: shàng kè
+  - chinese: 。
+    pinyin: ''
+  english: The students are in class.
+
+- segments:
+  - chinese: 医生
+    pinyin: yī shēng
+  - chinese: 们
+    pinyin: men
+  - chinese: 很
+    pinyin: hěn
+  - chinese: 忙
+    pinyin: máng
+  - chinese: 。
+    pinyin: ''
+  english: The doctors are very busy.
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,10 +8,10 @@ export default function Home() {
             Erudify
           </span>
           <a
-            href="#get-started"
+            href="/read"
             className="rounded-full bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700"
           >
-            Get Started
+            Start Studying
           </a>
         </nav>
       </header>
@@ -31,7 +31,7 @@ export default function Home() {
           </p>
           <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
-              href="#get-started"
+              href="/read"
               className="rounded-full bg-red-600 px-8 py-3 text-lg font-medium text-white transition-colors hover:bg-red-700"
             >
               Start Learning Free
@@ -97,10 +97,10 @@ export default function Home() {
             Erudify.
           </p>
           <a
-            href="#"
+            href="/read"
             className="inline-block rounded-full bg-red-600 px-8 py-3 text-lg font-medium text-white transition-colors hover:bg-red-700"
           >
-            Create Free Account
+            Start Studying Now
           </a>
         </section>
       </main>

--- a/src/app/read/page.tsx
+++ b/src/app/read/page.tsx
@@ -1,0 +1,610 @@
+"use client";
+
+import {
+  useState,
+  useEffect,
+  useRef,
+  useMemo,
+  KeyboardEvent,
+  ChangeEvent,
+  useCallback,
+} from "react";
+import Link from "next/link";
+import type {
+  Exercise,
+  StudentProgress,
+  ExerciseHistory,
+  WordIntervalChange,
+} from "@/lib/types";
+import {
+  selectNextExercise,
+  updateWordSuccess,
+  updateWordFailure,
+  addExerciseToHistory,
+  getExerciseWords,
+  getPinyinForWord,
+} from "@/lib/exercises";
+import { processPinyinInput } from "@/lib/pinyin";
+
+const STORAGE_KEY = "erudify-progress";
+
+/**
+ * Load student progress from localStorage
+ */
+function loadProgress(): StudentProgress {
+  if (typeof window === "undefined") {
+    return { words: {}, history: [], seenExercises: new Set() };
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      return {
+        words: parsed.words || {},
+        history: parsed.history || [],
+        seenExercises: new Set(parsed.seenExercises || []),
+      };
+    }
+  } catch (error) {
+    console.error("Failed to load progress:", error);
+  }
+
+  return { words: {}, history: [], seenExercises: new Set() };
+}
+
+/**
+ * Save student progress to localStorage
+ */
+function saveProgress(progress: StudentProgress): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    const toStore = {
+      words: progress.words,
+      history: progress.history,
+      seenExercises: Array.from(progress.seenExercises),
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(toStore));
+  } catch (error) {
+    console.error("Failed to save progress:", error);
+  }
+}
+
+/**
+ * Parse YAML exercises (simple parser for our specific format)
+ */
+function parseExercises(yaml: string): Exercise[] {
+  const exercises: Exercise[] = [];
+  const lines = yaml.split("\n");
+
+  let currentExercise: Exercise | null = null;
+  let currentSegment: { chinese?: string; pinyin?: string } | null = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (trimmed === "- segments:") {
+      // Start new exercise
+      if (currentExercise) {
+        exercises.push(currentExercise);
+      }
+      currentExercise = { segments: [], english: "" };
+      currentSegment = null;
+    } else if (trimmed.startsWith("- chinese:")) {
+      // Start new segment
+      if (currentSegment && currentSegment.chinese && currentExercise) {
+        currentExercise.segments.push({
+          chinese: currentSegment.chinese,
+          pinyin: currentSegment.pinyin || "",
+        });
+      }
+      currentSegment = { chinese: trimmed.slice(10).trim() };
+    } else if (trimmed.startsWith("pinyin:")) {
+      // Add pinyin to current segment
+      if (currentSegment) {
+        currentSegment.pinyin = trimmed.slice(7).trim().replace(/'/g, "");
+      }
+    } else if (trimmed.startsWith("english:")) {
+      // Add English translation
+      if (currentSegment && currentSegment.chinese && currentExercise) {
+        currentExercise.segments.push({
+          chinese: currentSegment.chinese,
+          pinyin: currentSegment.pinyin || "",
+        });
+        currentSegment = null;
+      }
+      if (currentExercise) {
+        currentExercise.english = trimmed.slice(8).trim();
+      }
+    }
+  }
+
+  // Don't forget the last exercise
+  if (currentExercise) {
+    exercises.push(currentExercise);
+  }
+
+  return exercises;
+}
+
+/**
+ * Normalize pinyin for comparison (lowercase, remove spaces)
+ */
+function normalizePinyin(pinyin: string): string {
+  return pinyin.toLowerCase().replace(/\s+/g, "");
+}
+
+/**
+ * Format duration in short form (e.g., "1w 2d", "3h 15min", "30sec")
+ */
+function formatDuration(seconds: number): string {
+  const weeks = Math.floor(seconds / (7 * 24 * 60 * 60));
+  seconds %= 7 * 24 * 60 * 60;
+  const days = Math.floor(seconds / (24 * 60 * 60));
+  seconds %= 24 * 60 * 60;
+  const hours = Math.floor(seconds / (60 * 60));
+  seconds %= 60 * 60;
+  const minutes = Math.floor(seconds / 60);
+  seconds = Math.floor(seconds % 60);
+
+  const parts: string[] = [];
+
+  if (weeks > 0) parts.push(`${weeks}w`);
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}min`);
+  if (seconds > 0 && parts.length === 0) parts.push(`${seconds}sec`);
+
+  // Return at most 2 parts
+  return parts.slice(0, 2).join(" ") || "0sec";
+}
+
+/**
+ * Format a date for display
+ */
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleString();
+}
+
+export default function ReadPage() {
+  const [exercises, setExercises] = useState<Exercise[]>([]);
+  const [progress, setProgress] = useState<StudentProgress>(() => loadProgress());
+  const [displayedExerciseIndex, setDisplayedExerciseIndex] = useState<number | null>(null);
+  const [currentInputIndex, setCurrentInputIndex] = useState(0);
+  const [inputValue, setInputValue] = useState("");
+  const [showHint, setShowHint] = useState(false);
+  const [hintedWordIndices, setHintedWordIndices] = useState<Set<number>>(new Set()); // Track which word indices had hints
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Load exercises on mount
+  useEffect(() => {
+    async function loadExercises() {
+      try {
+        const response = await fetch("/exercises_1.yaml");
+        const yamlText = await response.text();
+
+        const parsed = parseExercises(yamlText);
+        setExercises(parsed);
+      } catch (error) {
+        console.error("Failed to load exercises:", error);
+      }
+    }
+
+    loadExercises();
+  }, []);
+
+  // Calculate the next exercise recommendation
+  const nextExerciseData = useMemo(() => {
+    if (exercises.length === 0) {
+      return null;
+    }
+    return selectNextExercise(exercises, progress);
+  }, [exercises, progress]);
+
+  // Set initial exercise when exercises load
+  useEffect(() => {
+    if (displayedExerciseIndex === null && nextExerciseData) {
+      setDisplayedExerciseIndex(nextExerciseData.index);
+    }
+  }, [displayedExerciseIndex, nextExerciseData]);
+
+  // Get the currently displayed exercise
+  const currentExercise = displayedExerciseIndex !== null ? exercises[displayedExerciseIndex] : null;
+  const currentIndex = displayedExerciseIndex ?? -1;
+  const targetWord = nextExerciseData?.index === displayedExerciseIndex ? nextExerciseData.targetWord : undefined;
+
+  // Save progress whenever it changes
+  useEffect(() => {
+    saveProgress(progress);
+  }, [progress]);
+
+  // Focus input when currentInputIndex changes
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, [currentInputIndex]);
+
+  // Get segments that need pinyin input (non-empty pinyin)
+  const inputSegments = useMemo(() => {
+    return currentExercise
+      ? currentExercise.segments.filter((seg) => seg.pinyin !== "")
+      : [];
+  }, [currentExercise]);
+  const totalInputs = inputSegments.length;
+
+  // Move to next exercise (pass the updated progress to get correct next exercise)
+  const advanceToNextExercise = useCallback((updatedProgress: StudentProgress) => {
+    const next = selectNextExercise(exercises, updatedProgress);
+    if (next) {
+      setDisplayedExerciseIndex(next.index);
+    }
+    setCurrentInputIndex(0);
+    setInputValue("");
+    setShowHint(false);
+    setHintedWordIndices(new Set());
+  }, [exercises]);
+
+  // Check if input matches and advance to next segment
+  const checkAndAdvance = useCallback(
+    (newValue: string) => {
+      const currentSegment = inputSegments[currentInputIndex];
+      if (
+        currentSegment &&
+        normalizePinyin(newValue) === normalizePinyin(currentSegment.pinyin)
+      ) {
+        // Move to next segment
+        if (currentInputIndex < totalInputs - 1) {
+          setCurrentInputIndex((prev) => prev + 1);
+          setInputValue("");
+          setShowHint(false);
+        } else {
+          // All segments completed - update progress and immediately advance
+          if (currentExercise) {
+            const completedAt = Date.now(); // Use same timestamp for all words
+            let newProgress = progress;
+            const words = getExerciseWords(currentExercise);
+            const wordChanges: WordIntervalChange[] = [];
+
+            // Update each word based on whether a hint was used for that specific word
+            for (let i = 0; i < words.length; i++) {
+              const word = words[i];
+              const pinyin = getPinyinForWord(currentExercise, word);
+              
+              if (hintedWordIndices.has(i)) {
+                // Hint was used for this word - mark as failure
+                const result = updateWordFailure(word, pinyin, newProgress, completedAt);
+                newProgress = result.progress;
+                wordChanges.push(result.change);
+              } else {
+                // No hint for this word - mark as success
+                const result = updateWordSuccess(word, pinyin, newProgress, completedAt);
+                newProgress = result.progress;
+                wordChanges.push(result.change);
+              }
+            }
+
+            // Add to history (success if no hints were used at all)
+            newProgress = addExerciseToHistory(
+              currentIndex,
+              hintedWordIndices.size === 0,
+              currentExercise,
+              wordChanges,
+              newProgress
+            );
+
+            setProgress(newProgress);
+
+            // Immediately advance to next exercise with updated progress
+            advanceToNextExercise(newProgress);
+          }
+        }
+      }
+    },
+    [currentInputIndex, inputSegments, totalInputs, currentExercise, progress, hintedWordIndices, currentIndex, advanceToNextExercise]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      const key = e.key;
+
+      // Handle Escape key for hints
+      if (key === "Escape") {
+        e.preventDefault();
+        if (!showHint && currentInputIndex < inputSegments.length) {
+          setInputValue("");
+          setShowHint(true);
+          // Track that this specific word index had a hint
+          setHintedWordIndices((prev) => new Set(prev).add(currentInputIndex));
+        }
+        return;
+      }
+
+      // Check if it's a tone number (0-4)
+      if (/^[0-4]$/.test(key)) {
+        e.preventDefault();
+        const input = e.currentTarget;
+        const selectionStart = input.selectionStart ?? inputValue.length;
+
+        const { newText, newCursorPos } = processPinyinInput(
+          inputValue,
+          selectionStart,
+          parseInt(key, 10)
+        );
+
+        setInputValue(newText);
+        checkAndAdvance(newText);
+
+        requestAnimationFrame(() => {
+          input.setSelectionRange(newCursorPos, newCursorPos);
+        });
+      }
+    },
+    [inputValue, checkAndAdvance, showHint, currentInputIndex, inputSegments]
+  );
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const newValue = e.target.value;
+      setInputValue(newValue);
+      checkAndAdvance(newValue);
+    },
+    [checkAndAdvance]
+  );
+
+  /**
+   * Get recent history (last 3 exercises)
+   */
+  function getRecentHistory(): ExerciseHistory[] {
+    return progress.history.slice(-3).reverse();
+  }
+
+  /**
+   * Clear all progress and start from scratch
+   */
+  const handleClearProgress = useCallback(() => {
+    if (confirm("Are you sure you want to clear all progress? This cannot be undone.")) {
+      const emptyProgress: StudentProgress = {
+        words: {},
+        history: [],
+        seenExercises: new Set(),
+      };
+      setProgress(emptyProgress);
+      saveProgress(emptyProgress);
+
+      // Use advanceToNextExercise with empty progress to select first exercise
+      advanceToNextExercise(emptyProgress);
+    }
+  }, [advanceToNextExercise]);
+
+  if (!currentExercise) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-lg text-zinc-600">Loading exercises...</div>
+      </div>
+    );
+  }
+
+  // Track which segment index we're currently at for rendering
+  let inputSegmentIndex = 0;
+
+  return (
+    <div className="flex min-h-screen bg-zinc-50 dark:bg-zinc-950">
+      <style>{`
+        @keyframes historySlideIn {
+          from {
+            opacity: 0;
+            transform: translateY(-10px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+        .history-item-animate {
+          animation: historySlideIn 0.3s ease-out;
+        }
+      `}</style>
+      {/* Sidebar */}
+      <aside className="w-80 overflow-y-auto border-r border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+        <h2 className="mb-4 text-xl font-bold text-zinc-900 dark:text-white">
+          Erudify
+        </h2>
+
+        <nav className="space-y-2">
+          <Link
+            href="/"
+            className="block rounded-lg px-3 py-2 text-sm text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+          >
+            Home
+          </Link>
+          <Link
+            href="/read"
+            className="block rounded-lg bg-red-50 px-3 py-2 text-sm font-medium text-red-600 dark:bg-red-950 dark:text-red-400"
+          >
+            Study
+          </Link>
+        </nav>
+
+        <div className="mt-8">
+          <h3 className="mb-2 text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+            Progress
+          </h3>
+          <div className="text-sm text-zinc-600 dark:text-zinc-400">
+            <div>Words: {Object.keys(progress.words).length}</div>
+            <div>Exercises: {progress.seenExercises.size}</div>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <h3 className="mb-2 text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+            Recent History
+          </h3>
+          <div className="space-y-3">
+            {getRecentHistory().map((item) => (
+              <div
+                key={item.completedAt}
+                className="history-item-animate rounded-lg border border-zinc-200 p-3 text-xs dark:border-zinc-700"
+              >
+                <div className="mb-1 flex items-center gap-2">
+                  <span className={item.success ? "text-green-600" : "text-red-600"}>
+                    {item.success ? "✓" : "✗"}
+                  </span>
+                  <span className="font-medium text-zinc-900 dark:text-white">
+                    {item.chinese}
+                  </span>
+                </div>
+                <div className="mb-1 text-zinc-500 dark:text-zinc-400">
+                  {item.pinyin}
+                </div>
+                <div className="mb-2 text-zinc-600 dark:text-zinc-300">
+                  {item.english}
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {item.wordChanges?.map((change, cidx) => {
+                    // Determine color: red for failure, gray for early review, green for normal increase
+                    let colorClass: string;
+                    if (change.wasFailure) {
+                      colorClass = "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400";
+                    } else if (change.wasEarlyReview) {
+                      colorClass = "bg-zinc-100 text-zinc-600 dark:bg-zinc-700/50 dark:text-zinc-400";
+                    } else {
+                      colorClass = "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400";
+                    }
+
+                    // Show + for increases, nothing for failures/resets
+                    const showPlus = !change.wasFailure && (
+                      change.oldIntervalSeconds === null ||
+                      change.newIntervalSeconds > change.oldIntervalSeconds
+                    );
+
+                    return (
+                      <span
+                        key={cidx}
+                        className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 ${colorClass}`}
+                        title={`Next review: ${formatDate(change.nextReview)}`}
+                      >
+                        <span>{change.word}</span>
+                        <span>
+                          {showPlus ? "+" : ""}
+                          {formatDuration(change.newIntervalSeconds)}
+                        </span>
+                      </span>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <button
+            onClick={handleClearProgress}
+            className="w-full rounded-lg border border-red-300 px-3 py-2 text-sm text-red-600 hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-950/50"
+          >
+            Clear Progress
+          </button>
+        </div>
+      </aside>
+
+      {/* Main content */}
+      <main className="flex-1 p-8">
+        <div className="mx-auto max-w-4xl">
+          {/* Current exercise */}
+          <div className="mb-8 rounded-2xl bg-white p-8 shadow-sm dark:bg-zinc-900">
+            {targetWord && (
+              <div className="mb-4 text-sm text-zinc-500 dark:text-zinc-400">
+                Reviewing: <span className="font-medium">{targetWord}</span>
+              </div>
+            )}
+
+            {/* Chinese sentence with input fields */}
+            <div className="flex flex-wrap items-start gap-2 text-4xl">
+              {currentExercise.segments.map((segment, idx) => {
+                // Punctuation or empty pinyin
+                if (segment.pinyin === "") {
+                  return (
+                    <div key={idx} className="flex flex-col items-center gap-1">
+                      <span className="text-zinc-900 dark:text-white">
+                        {segment.chinese}
+                      </span>
+                    </div>
+                  );
+                }
+
+                const segmentInputIndex = inputSegmentIndex;
+                inputSegmentIndex++;
+
+                const isCurrentInput = segmentInputIndex === currentInputIndex;
+                const isCompleted = segmentInputIndex < currentInputIndex;
+
+                const pinyinWidth = `${segment.pinyin.length * 0.6 + 1}rem`;
+
+                return (
+                  <div key={idx} className="flex flex-col items-center gap-1">
+                    <span className="text-zinc-900 dark:text-white">
+                      {segment.chinese}
+                    </span>
+                    {isCurrentInput ? (
+                      <input
+                        ref={inputRef}
+                        type="text"
+                        value={inputValue}
+                        onChange={handleChange}
+                        onKeyDown={handleKeyDown}
+                        placeholder={showHint ? segment.pinyin : ""}
+                        style={{ width: pinyinWidth }}
+                        className="rounded border border-red-300 bg-red-50 px-2 py-1 text-center text-base text-zinc-900 placeholder-zinc-500 focus:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-500/20 dark:border-red-700 dark:bg-red-900/20 dark:text-white dark:placeholder-zinc-400"
+                        autoFocus
+                      />
+                    ) : isCompleted ? (
+                      <span 
+                        className="inline-block px-2 py-1 text-center text-base text-green-600 dark:text-green-400"
+                        style={{ width: pinyinWidth }}
+                      >
+                        {segment.pinyin}
+                      </span>
+                    ) : (
+                      <span 
+                        className="inline-block px-2 py-1 text-center text-base text-zinc-400 dark:text-zinc-600"
+                        style={{ width: pinyinWidth }}
+                      >
+                        ___
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Instructions */}
+          <div className="rounded-lg bg-zinc-100 p-4 text-sm text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+            <p className="mb-2 font-medium text-zinc-700 dark:text-zinc-300">
+              How to study:
+            </p>
+            <ul className="list-inside list-disc space-y-1">
+              <li>Type pinyin followed by a tone number (1-4) for tone marks</li>
+              <li>
+                Example:{" "}
+                <code className="rounded bg-zinc-200 px-1 dark:bg-zinc-700">
+                  wo3
+                </code>{" "}
+                becomes wǒ
+              </li>
+              <li>
+                Press{" "}
+                <kbd className="rounded bg-zinc-200 px-2 py-1 font-mono dark:bg-zinc-700">
+                  Escape
+                </kbd>{" "}
+                to see a hint (will affect your review schedule)
+              </li>
+              <li>Use 0 to remove the last tone mark</li>
+              <li>v = ü (e.g., lv4 → lǜ)</li>
+            </ul>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/lib/exercises.ts
+++ b/src/lib/exercises.ts
@@ -1,0 +1,281 @@
+import type { Exercise, StudentProgress, WordIntervalChange } from "./types";
+
+const INITIAL_INTERVAL = 30; // 30 seconds
+const INTERVAL_MULTIPLIER = 5;
+const EARLY_REVIEW_MULTIPLIER = 1.05; // For words reviewed before their scheduled time
+
+/**
+ * Get all words from an exercise (excluding punctuation - segments without pinyin)
+ */
+export function getExerciseWords(exercise: Exercise): string[] {
+  return exercise.segments
+    .filter((seg) => seg.pinyin !== "")
+    .map((seg) => seg.chinese);
+}
+
+/**
+ * Check if an exercise contains a specific word
+ */
+export function exerciseContainsWord(exercise: Exercise, word: string): boolean {
+  return getExerciseWords(exercise).includes(word);
+}
+
+/**
+ * Get words from an exercise that the student hasn't seen before
+ */
+export function getNewWords(
+  exercise: Exercise,
+  progress: StudentProgress
+): string[] {
+  return getExerciseWords(exercise).filter((word) => !progress.words[word]);
+}
+
+/**
+ * Select the next exercise for the student based on spaced repetition algorithm
+ */
+export function selectNextExercise(
+  exercises: Exercise[],
+  progress: StudentProgress
+): { exercise: Exercise; index: number; targetWord?: string } | null {
+  const now = Date.now();
+
+  // Find words that need review (nextReview is in the past)
+  const wordsNeedingReview = Object.values(progress.words)
+    .filter((wp) => wp.nextReview <= now)
+    .sort((a, b) => a.nextReview - b.nextReview); // sort by nearest review time
+
+  if (wordsNeedingReview.length > 0) {
+    // We have words to review - pick the most urgent one
+    const targetWord = wordsNeedingReview[0].word;
+
+    // Filter exercises that contain the target word
+    const candidateExercises = exercises
+      .map((ex, idx) => ({ exercise: ex, index: idx }))
+      .filter(({ exercise }) => exerciseContainsWord(exercise, targetWord));
+
+    if (candidateExercises.length === 0) {
+      // This shouldn't happen, but handle it gracefully
+      return selectNewExercise(exercises, progress);
+    }
+
+    // Score each exercise based on priorities
+    const scoredExercises = candidateExercises.map(({ exercise, index }) => {
+      let score = 0;
+
+      const newWords = getNewWords(exercise, progress);
+      const hasNewWords = newWords.length > 0;
+      const exerciseWords = getExerciseWords(exercise);
+
+      // Priority 1: Prefer exercises with no new words (high priority)
+      if (!hasNewWords) {
+        score += 1000;
+      }
+
+      // Priority 2: Prefer exercises with words that have future review dates
+      const futureReviewWords = exerciseWords.filter((word) => {
+        const wp = progress.words[word];
+        return wp && wp.nextReview > now;
+      });
+      score += futureReviewWords.length * 100;
+
+      // Priority 3: Prefer exercises not seen before
+      if (!progress.seenExercises.has(index)) {
+        score += 10;
+      }
+
+      return { exercise, index, score };
+    });
+
+    // Sort by score (highest first)
+    scoredExercises.sort((a, b) => b.score - a.score);
+
+    return {
+      exercise: scoredExercises[0].exercise,
+      index: scoredExercises[0].index,
+      targetWord,
+    };
+  }
+
+  // No words need review - pick a new exercise with new words
+  return selectNewExercise(exercises, progress);
+}
+
+/**
+ * Select a new exercise (one that introduces new words)
+ */
+function selectNewExercise(
+  exercises: Exercise[],
+  progress: StudentProgress
+): { exercise: Exercise; index: number } | null {
+  // Find the first exercise that contains at least one new word
+  for (let i = 0; i < exercises.length; i++) {
+    const exercise = exercises[i];
+    const newWords = getNewWords(exercise, progress);
+
+    if (newWords.length > 0) {
+      return { exercise, index: i };
+    }
+  }
+
+  // All exercises have been seen with all words known
+  // Just pick the first unseen exercise, or cycle back to the beginning
+  for (let i = 0; i < exercises.length; i++) {
+    if (!progress.seenExercises.has(i)) {
+      return { exercise: exercises[i], index: i };
+    }
+  }
+
+  // Everything has been seen - start from the beginning
+  return exercises.length > 0 ? { exercise: exercises[0], index: 0 } : null;
+}
+
+/**
+ * Update word progress after a successful recall
+ * Returns new progress and the interval change info
+ * @param completedAt - timestamp when the exercise was completed (used for all words)
+ */
+export function updateWordSuccess(
+  word: string,
+  pinyin: string,
+  progress: StudentProgress,
+  completedAt: number
+): { progress: StudentProgress; change: WordIntervalChange } {
+  const existing = progress.words[word];
+
+  let newInterval: number;
+  let consecutiveSuccesses: number;
+  let wasEarlyReview = false;
+
+  if (!existing) {
+    // First time seeing this word
+    newInterval = INITIAL_INTERVAL;
+    consecutiveSuccesses = 1;
+  } else if (existing.nextReview > completedAt) {
+    // Early review - word was reviewed before its scheduled time
+    // Use smaller multiplier (1.05x)
+    newInterval = Math.round(existing.intervalSeconds * EARLY_REVIEW_MULTIPLIER);
+    consecutiveSuccesses = existing.consecutiveSuccesses + 1;
+    wasEarlyReview = true;
+  } else {
+    // Normal review - word was due or overdue
+    // Use full multiplier (5x)
+    newInterval = existing.intervalSeconds * INTERVAL_MULTIPLIER;
+    consecutiveSuccesses = existing.consecutiveSuccesses + 1;
+  }
+
+  const nextReview = completedAt + newInterval * 1000;
+
+  const change: WordIntervalChange = {
+    word,
+    pinyin,
+    oldIntervalSeconds: existing?.intervalSeconds ?? null,
+    newIntervalSeconds: newInterval,
+    nextReview,
+    wasEarlyReview,
+    wasFailure: false,
+  };
+
+  return {
+    progress: {
+      ...progress,
+      words: {
+        ...progress.words,
+        [word]: {
+          word,
+          lastReviewed: completedAt,
+          nextReview,
+          intervalSeconds: newInterval,
+          consecutiveSuccesses,
+        },
+      },
+    },
+    change,
+  };
+}
+
+/**
+ * Update word progress after a failed recall
+ * Returns new progress and the interval change info
+ * @param completedAt - timestamp when the exercise was completed (used for all words)
+ */
+export function updateWordFailure(
+  word: string,
+  pinyin: string,
+  progress: StudentProgress,
+  completedAt: number
+): { progress: StudentProgress; change: WordIntervalChange } {
+  const existing = progress.words[word];
+  const nextReview = completedAt + INITIAL_INTERVAL * 1000;
+
+  const change: WordIntervalChange = {
+    word,
+    pinyin,
+    oldIntervalSeconds: existing?.intervalSeconds ?? null,
+    newIntervalSeconds: INITIAL_INTERVAL,
+    nextReview,
+    wasEarlyReview: false, // Failures are never considered "early"
+    wasFailure: true,
+  };
+
+  return {
+    progress: {
+      ...progress,
+      words: {
+        ...progress.words,
+        [word]: {
+          word,
+          lastReviewed: completedAt,
+          nextReview,
+          intervalSeconds: INITIAL_INTERVAL,
+          consecutiveSuccesses: 0,
+        },
+      },
+    },
+    change,
+  };
+}
+
+/**
+ * Mark an exercise as completed
+ */
+export function addExerciseToHistory(
+  exerciseIndex: number,
+  success: boolean,
+  exercise: Exercise,
+  wordChanges: WordIntervalChange[],
+  progress: StudentProgress
+): StudentProgress {
+  const newSeenExercises = new Set(progress.seenExercises);
+  newSeenExercises.add(exerciseIndex);
+
+  const chinese = exercise.segments.map((s) => s.chinese).join("");
+  const pinyin = exercise.segments
+    .map((s) => s.pinyin)
+    .filter((p) => p)
+    .join(" ");
+
+  return {
+    ...progress,
+    history: [
+      ...progress.history,
+      {
+        exerciseIndex,
+        completedAt: Date.now(),
+        success,
+        chinese,
+        pinyin,
+        english: exercise.english,
+        wordChanges,
+      },
+    ],
+    seenExercises: newSeenExercises,
+  };
+}
+
+/**
+ * Get pinyin for a word from exercise segments
+ */
+export function getPinyinForWord(exercise: Exercise, word: string): string {
+  const segment = exercise.segments.find((s) => s.chinese === word);
+  return segment?.pinyin ?? "";
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Represents a segment of an exercise (a word or punctuation)
+ */
+export interface ExerciseSegment {
+  chinese: string;
+  pinyin: string;
+}
+
+/**
+ * Represents a complete exercise with Chinese text, pinyin, and English translation
+ */
+export interface Exercise {
+  segments: ExerciseSegment[];
+  english: string;
+}
+
+/**
+ * Tracks a student's progress for a specific word
+ */
+export interface WordProgress {
+  word: string;
+  lastReviewed: number; // timestamp
+  nextReview: number; // timestamp
+  intervalSeconds: number; // current interval (30, 150, 750, etc.)
+  consecutiveSuccesses: number; // count of consecutive successful recalls
+}
+
+/**
+ * Tracks interval change for a word after review
+ */
+export interface WordIntervalChange {
+  word: string;
+  pinyin: string;
+  oldIntervalSeconds: number | null; // null if new word
+  newIntervalSeconds: number;
+  nextReview: number; // timestamp
+  wasEarlyReview: boolean; // true if reviewed before scheduled time (1.05x multiplier)
+  wasFailure: boolean; // true if this was a failure (hint used)
+}
+
+/**
+ * Tracks which exercises the student has completed
+ */
+export interface ExerciseHistory {
+  exerciseIndex: number;
+  completedAt: number; // timestamp
+  success: boolean;
+  chinese: string; // Full Chinese sentence
+  pinyin: string; // Full pinyin
+  english: string; // English translation
+  wordChanges: WordIntervalChange[]; // Changes to each word's interval
+}
+
+/**
+ * Student progress data stored in localStorage
+ */
+export interface StudentProgress {
+  words: Record<string, WordProgress>; // keyed by word
+  history: ExerciseHistory[];
+  seenExercises: Set<number>; // indices of exercises already seen
+}


### PR DESCRIPTION
## Summary

- Add a new study page at `/read` for practicing Chinese reading with spaced repetition
- Implement per-word hint tracking so only words where hints are used get penalized
- Show animated history sidebar with word interval changes (green for success, red for failure, gray for early review)

### Features
- Pinyin input with tone mark support (type `wo3` for `wǒ`)
- Press Escape to show hint for current word (affects only that word's review schedule)
- Spaced repetition: 30s initial, 5x multiplier on success, 1.05x for early reviews
- Progress persisted to localStorage
- Exercise selection prioritizes words due for review