### PR TITLE
Fix review target selection fallback and HSK filtering

### DIFF
--- a/src/lib/exercises.test.ts
+++ b/src/lib/exercises.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { selectNextExercise } from "./exercises";
+import type { Exercise, StudentProgress } from "./domain";
+
+describe("selectNextExercise", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("iterates to the next overdue word when the first overdue word has no unlocked sentence", () => {
+    const now = new Date("2026-02-11T12:00:00.000Z").getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    const exercises: Exercise[] = [
+      {
+        // Contains 你 (overdue) but also 好 (also overdue), so locked for reviewing 你.
+        segments: [
+          { chinese: "你", pinyin: "ni3" },
+          { chinese: "好", pinyin: "hao3" },
+        ],
+        english: "Hello",
+      },
+      {
+        // Contains 学 (overdue target) and only known future words, so unlocked.
+        segments: [
+          { chinese: "我", pinyin: "wo3" },
+          { chinese: "学", pinyin: "xue2" },
+        ],
+        english: "I study",
+      },
+    ];
+
+    const progress: StudentProgress = {
+      words: {
+        你: {
+          word: "你",
+          lastReviewed: now - 60000,
+          nextReview: now - 1000,
+          intervalSeconds: 30,
+          consecutiveSuccesses: 1,
+        },
+        好: {
+          word: "好",
+          lastReviewed: now - 60000,
+          nextReview: now - 500,
+          intervalSeconds: 30,
+          consecutiveSuccesses: 1,
+        },
+        学: {
+          word: "学",
+          lastReviewed: now - 60000,
+          nextReview: now - 900,
+          intervalSeconds: 30,
+          consecutiveSuccesses: 1,
+        },
+        我: {
+          word: "我",
+          lastReviewed: now - 60000,
+          nextReview: now + 3600000,
+          intervalSeconds: 3600,
+          consecutiveSuccesses: 3,
+        },
+      },
+      history: [],
+      exerciseLastSeen: {},
+      dailyMetricsHistory: {},
+    };
+
+    const result = selectNextExercise(exercises, progress, ["你", "好", "我", "学"]);
+
+    expect(result).not.toBeNull();
+    expect(result?.targetWord).toBe("学");
+    expect(result?.index).toBe(1);
+  });
+
+  it("only considers overdue words that are in the loaded ordered word list", () => {
+    const now = new Date("2026-02-11T12:00:00.000Z").getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    const exercises: Exercise[] = [
+      {
+        segments: [{ chinese: "X", pinyin: "x" }],
+        english: "external word",
+      },
+      {
+        segments: [{ chinese: "你", pinyin: "ni3" }],
+        english: "you",
+      },
+    ];
+
+    const progress: StudentProgress = {
+      words: {
+        X: {
+          word: "X",
+          lastReviewed: now - 60000,
+          nextReview: now - 2000,
+          intervalSeconds: 30,
+          consecutiveSuccesses: 1,
+        },
+        你: {
+          word: "你",
+          lastReviewed: now - 60000,
+          nextReview: now - 1000,
+          intervalSeconds: 30,
+          consecutiveSuccesses: 1,
+        },
+      },
+      history: [],
+      exerciseLastSeen: {},
+      dailyMetricsHistory: {},
+    };
+
+    const result = selectNextExercise(exercises, progress, ["你"]);
+
+    expect(result).not.toBeNull();
+    expect(result?.targetWord).toBe("你");
+    expect(result?.index).toBe(1);
+  });
+});

--- a/src/lib/exercises.ts
+++ b/src/lib/exercises.ts
@@ -51,33 +51,43 @@ export function selectNextExercise(
   orderedWordList: string[] = []
 ): { exercise: Exercise; index: number; targetWord?: string } | null {
   const now = Date.now();
+  const allowedWords = new Set(orderedWordList);
 
-  // Find words that need review (nextReview is in the past)
+  // Find words that need review (nextReview is in the past), limited to
+  // the loaded ordered word list when it is provided.
   const wordsNeedingReview = Object.values(progress.words)
-    .filter((wp) => wp.nextReview <= now)
+    .filter((wp) => {
+      if (wp.nextReview > now) return false;
+      if (allowedWords.size === 0) return true;
+      return allowedWords.has(wp.word);
+    })
     .sort((a, b) => a.nextReview - b.nextReview); // sort by nearest review time
 
-  if (wordsNeedingReview.length > 0) {
-    // We have words to review - pick the most urgent one
-    const targetWord = wordsNeedingReview[0].word;
+  for (const reviewWord of wordsNeedingReview) {
+    const targetWord = reviewWord.word;
 
-    // Use the new helper to score candidates
-    const scoredExercises = getExerciseCandidates(targetWord, exercises, progress);
+    // A review sentence is unlocked only when all other words are already known
+    // (present in progress and not currently due).
+    const scoredExercises = getExerciseCandidates(targetWord, exercises, progress).filter(
+      ({ exercise }) => {
+        const otherWords = getExerciseWords(exercise).filter((w) => w !== targetWord);
+        return otherWords.every((w) => {
+          const wp = progress.words[w];
+          return wp != null && wp.nextReview > now;
+        });
+      }
+    );
 
-    if (scoredExercises.length === 0) {
-      // This word is in progress but no exercises contain it?
-      // Fall back to new words or next in list
-      return selectNewExercise(exercises, progress, orderedWordList);
+    if (scoredExercises.length > 0) {
+      return {
+        exercise: scoredExercises[0].exercise,
+        index: scoredExercises[0].index,
+        targetWord,
+      };
     }
-
-    return {
-      exercise: scoredExercises[0].exercise,
-      index: scoredExercises[0].index,
-      targetWord,
-    };
   }
 
-  // No words need review - pick the next word in the HSK list that isn't mastered
+  // No teachable review words - pick the next word in the HSK list that isn't mastered
   return selectNewExercise(exercises, progress, orderedWordList);
 }
 


### PR DESCRIPTION
## Summary
- iterate through overdue words in order instead of stopping at the first overdue word
- skip overdue words that have no unlocked review sentence and continue to the next overdue word
- restrict overdue review candidates to words present in the loaded ordered list (HSK-1 list)
- add regression tests for both behaviors

## Testing
- npx vitest src/lib/exercises.test.ts