### PR TITLE
Improve exercise candidate ranking for beginner readability

### DIFF
--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -51,9 +51,23 @@ export function DebugModal({
                     Option #{cand.index}{" "}
                     {cand.index === currentIndex && " (Selected)"}
                   </span>
-                  <span className="rounded bg-zinc-100 px-2 py-0.5 text-sm font-mono font-bold text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
-                    Score: {cand.score}
-                  </span>
+                </div>
+                <div className="mb-3 rounded-lg bg-zinc-100 p-2 text-xs font-mono text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200">
+                  <div>
+                    1) Outside ordered list: {cand.score.wordsNotInOrderedList}
+                  </div>
+                  <div>
+                    2) Unknown/review words: {cand.score.unknownOrReviewWordCount}
+                  </div>
+                  <div>
+                    3) Largest ordered index:{" "}
+                    {cand.score.largestOrderedWordIndex === -1
+                      ? "none"
+                      : cand.score.largestOrderedWordIndex}
+                  </div>
+                  <div>
+                    4) Chinese chars: {cand.score.chineseCharacterCount}
+                  </div>
                 </div>
                 <div className="mb-3">
                   <div className="text-lg text-zinc-900 dark:text-white">
@@ -64,17 +78,21 @@ export function DebugModal({
                   </div>
                 </div>
                 <div className="flex flex-wrap gap-2 text-xs">
-                  {Object.entries(cand.breakdown.wordScores).map(
-                    ([word, score]) => (
+                  {Object.entries(cand.breakdown.wordStatuses).map(
+                    ([word, status]) => (
                       <span
                         key={word}
                         className={`rounded-full px-2 py-0.5 ${
-                          score > 0
+                          status === "unknown"
                             ? "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
-                            : "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                            : status === "review"
+                              ? "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+                              : "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
                         }`}
                       >
-                        {word}: {score}
+                        {word}: {status}
+                        {cand.breakdown.orderedWordIndices[word] !== null &&
+                          ` (idx ${cand.breakdown.orderedWordIndices[word]})`}
                       </span>
                     )
                   )}

--- a/src/hooks/useExerciseSelection.ts
+++ b/src/hooks/useExerciseSelection.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { selectNextExercise } from "../lib/exercises";
+import { getExerciseCandidates, selectNextExercise } from "../lib/exercises";
 import type { Exercise, StudentProgress, ScoredExercise } from "../lib/domain";
 
 export interface UseExerciseSelectionReturn {
@@ -26,8 +26,8 @@ export function useExerciseSelection(
 
   const debugCandidates: ScoredExercise[] = useMemo(() => {
     if (!targetWord) return [];
-    return require("../lib/exercises").getExerciseCandidates(targetWord, exercises, progress);
-  }, [targetWord, exercises, progress]);
+    return getExerciseCandidates(targetWord, exercises, progress, wordList);
+  }, [targetWord, exercises, progress, wordList]);
 
   return { currentExercise, currentIndex, targetWord, debugCandidates };
 }

--- a/src/lib/domain/exercise.ts
+++ b/src/lib/domain/exercise.ts
@@ -12,10 +12,19 @@ export interface Exercise {
 export interface ScoredExercise {
   exercise: Exercise;
   index: number;
-  score: number;
+  score: {
+    wordsNotInOrderedList: number;
+    unknownOrReviewWordCount: number;
+    largestOrderedWordIndex: number;
+    chineseCharacterCount: number;
+  };
   breakdown: {
-    wordScores: Record<string, number>;
-    totalWordScore: number;
+    wordStatuses: Record<string, "known" | "review" | "unknown">;
+    orderedWordIndices: Record<string, number | null>;
+    wordsNotInOrderedList: number;
+    unknownOrReviewWordCount: number;
+    largestOrderedWordIndex: number;
+    chineseCharacterCount: number;
     lastSeen: number;
   };
 }

--- a/src/lib/exercises.test.ts
+++ b/src/lib/exercises.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import { getExerciseCandidates } from "./exercises";
+import type { Exercise, StudentProgress } from "./domain";
+
+function makeExercise(words: string[]): Exercise {
+  return {
+    segments: words.map((word) => ({ chinese: word, pinyin: "x" })),
+    english: words.join(" "),
+  };
+}
+
+function makeProgress(
+  words: StudentProgress["words"],
+  exerciseLastSeen: StudentProgress["exerciseLastSeen"] = {}
+): StudentProgress {
+  return {
+    words,
+    history: [],
+    exerciseLastSeen,
+    dailyMetricsHistory: {},
+  };
+}
+
+describe("getExerciseCandidates", () => {
+  it("prioritizes words close to the ordered list over longer advanced sentences", () => {
+    const exercises: Exercise[] = [
+      makeExercise(["你们", "什么时候", "到", "的"]),
+      makeExercise(["我", "的"]),
+    ];
+    const progress = makeProgress({});
+    const orderedWordList = ["的", "我", "你们", "什么时候", "到"];
+
+    const candidates = getExerciseCandidates("的", exercises, progress, orderedWordList);
+
+    expect(candidates[0].index).toBe(1);
+    expect(candidates[0].score).toEqual({
+      wordsNotInOrderedList: 0,
+      unknownOrReviewWordCount: 2,
+      largestOrderedWordIndex: 1,
+      chineseCharacterCount: 2,
+    });
+  });
+
+  it("treats known future-review words as free for score calculation", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-11T00:00:00.000Z"));
+    const future = Date.now() + 60_000;
+
+    const exercises: Exercise[] = [
+      makeExercise(["你", "的"]),
+      makeExercise(["我", "的"]),
+    ];
+    const progress = makeProgress({
+      你: {
+        word: "你",
+        lastReviewed: Date.now(),
+        nextReview: future,
+        intervalSeconds: 60,
+        consecutiveSuccesses: 1,
+      },
+    });
+    const orderedWordList = ["的", "我"];
+
+    const candidates = getExerciseCandidates("的", exercises, progress, orderedWordList);
+
+    expect(candidates[0].index).toBe(0);
+    expect(candidates[0].score.wordsNotInOrderedList).toBe(0);
+    expect(candidates[0].score.unknownOrReviewWordCount).toBe(1);
+
+    vi.useRealTimers();
+  });
+
+  it("uses chinese character count as tie-breaker after the first three score levels", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-11T00:00:00.000Z"));
+    const future = Date.now() + 60_000;
+
+    const exercises: Exercise[] = [
+      makeExercise(["的"]),
+      makeExercise(["的", "你们"]),
+    ];
+    const progress = makeProgress({
+      你们: {
+        word: "你们",
+        lastReviewed: Date.now(),
+        nextReview: future,
+        intervalSeconds: 60,
+        consecutiveSuccesses: 1,
+      },
+    });
+    const orderedWordList = ["的"];
+
+    const candidates = getExerciseCandidates("的", exercises, progress, orderedWordList);
+
+    expect(candidates[0].index).toBe(0);
+    expect(candidates[0].score).toEqual({
+      wordsNotInOrderedList: 0,
+      unknownOrReviewWordCount: 1,
+      largestOrderedWordIndex: 0,
+      chineseCharacterCount: 1,
+    });
+
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- replace scalar exercise scoring with a lexicographic score tuple optimized for beginner readability
- rank candidates by: (1) words outside ordered list, (2) unknown/review words, (3) largest ordered-word index, (4) Han character count
- treat words with future `nextReview` as free (excluded from scoring criteria)
- pass `orderedWordList` into candidate selection in review/new-word/debug paths
- update Exercise Selection Debug modal to display the new score hierarchy and per-word status/index details
- add unit tests for ranking priority, free known words, and character-count tie-break behavior

## Validation
- `npx vitest src/lib/exercises.test.ts`
- `npx eslint src/lib/exercises.ts src/lib/exercises.test.ts src/components/DebugModal.tsx src/lib/domain/exercise.ts src/hooks/useExerciseSelection.ts`
- `npx tsc --noEmit --pretty false`
